### PR TITLE
Whorl: bump build marker to re-trigger Pages deploy

### DIFF
--- a/whorl/index.html
+++ b/whorl/index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<!-- whorl · prototype build 2 -->
 <html lang="en">
 <head>
 <meta charset="utf-8" />


### PR DESCRIPTION
Follow-up to #17. The previous Pages deployment failed on GitHub's side, so this lands a fresh commit on `master` to re-trigger the Pages build.

- No behaviour change — adds a single build-marker HTML comment to `whorl/index.html`.
- Merging this should kick off a new Pages deployment; Whorl will then be live at `izgebayyurt.github.io/whorl/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R96pkZNidSbkw2qLphH6Z7

---
_Generated by [Claude Code](https://claude.ai/code/session_01R96pkZNidSbkw2qLphH6Z7)_