### PR TITLE
Whorl builds 10–12: free information, the Bazaar pass, the human retune, and the Living Ring

### DIFF
--- a/whorl/index.html
+++ b/whorl/index.html
@@ -185,6 +185,61 @@ body{
 .rcard.chosen:active{ transform:none; box-shadow:0 3px 0 var(--shadow); }
 .cards.locked .rcard:not(.chosen){ opacity:.42; pointer-events:none; }
 
+/* ---------- Bazaar excitement pass: rarity borders, badges, price column ---------- */
+.rcard.offer.rar-rare{ border-color:#f0a92c; }
+.rcard.offer.rar-epic{ border-color:#9b62d6; }
+.rcard.offer.rar-pack{ border-color:#f0a92c; background:#fff6e2; }
+.rcard.offer .pricewrap{ margin-left:auto; flex:none; display:flex; flex-direction:column; align-items:center; gap:2px; }
+.rcard.offer .pricewrap .price{ margin-left:0; }
+.rcard.offer .rarity{ font-family:var(--font-u); font-weight:800; font-size:7.5px; letter-spacing:.12em;
+  text-transform:uppercase; color:var(--ink-soft); text-align:center; }
+.rcard.offer.rar-rare .rarity{ color:#c07d10; }
+.rcard.offer.rar-epic .rarity{ color:#7c48b4; }
+.rcard.offer.sold .pricewrap{ visibility:hidden; }
+.rec-badge{ display:inline-block; margin-left:5px; font-size:8px; font-weight:800; letter-spacing:.3px;
+  text-transform:uppercase; color:#2c2733; background:#ffd15c; padding:1px 5px; border-radius:7px; border:1.5px solid #2c2733; vertical-align:middle; }
+.merge-badge{ display:inline-block; margin-left:5px; font-size:8px; font-weight:800; letter-spacing:.3px;
+  text-transform:uppercase; color:#fffdf6; background:#c07d10; padding:1px 5px; border-radius:7px; border:1.5px solid #2c2733; vertical-align:middle; }
+.rcard.offer.mergecard{ background:#fff3df; }
+/* the Arcane Pack reveal (pick 1 of 3) */
+.packreveal{ border:2.5px dashed #f0a92c; border-radius:15px; padding:8px; background:#fff6e2; }
+.pack-hd{ font-family:var(--font-d); font-weight:700; font-size:12px; color:#8a5a12; text-align:center; margin:0 0 7px; letter-spacing:.03em; }
+.rcard.offer.packchoice{ padding:9px 11px; }
+.rcard.offer.packchoice .rarity{ margin-left:auto; }
+/* Retire slot */
+.retire-sec{ margin-top:9px; }
+.retire-row{ display:flex; align-items:center; gap:8px; padding:8px 12px; background:var(--paper2);
+  border:2.5px dashed var(--ink); border-radius:13px; box-shadow:0 3px 0 var(--shadow); cursor:pointer;
+  transition:transform .08s var(--calm), box-shadow .08s var(--calm); }
+.retire-row:active{ transform:translateY(3px); box-shadow:0 0 0 var(--shadow); }
+.retire-row.cant{ opacity:.4; pointer-events:none; }
+.retire-lbl{ font-family:var(--font-d); font-weight:600; font-size:14px; color:var(--ink); }
+.retire-fee{ margin-left:auto; display:flex; align-items:center; gap:4px; font-family:var(--font-d); font-weight:700; font-size:13px; color:var(--ink-soft); }
+.retire-fee i{ width:12px; height:12px; border-radius:50%; background:var(--accent); border:2px solid var(--ink); flex:none; }
+.retire-hd{ font-family:var(--font-d); font-weight:700; font-size:12px; color:var(--ink); text-align:left; margin:2px 2px 8px; }
+.retire-grid{ display:grid; grid-template-columns:repeat(3,1fr); gap:6px; }
+.retire-card{ position:relative; display:flex; flex-direction:column; align-items:center; gap:4px; padding:8px 4px;
+  background:var(--card); border:2.5px solid var(--ink); border-radius:12px; box-shadow:0 3px 0 var(--shadow); cursor:pointer; }
+.retire-card:active{ transform:translateY(3px); box-shadow:0 0 0 var(--shadow); }
+.retire-card.sel{ background:var(--accent); border-color:#ef4a5a; }
+.retire-card .ic{ width:30px; height:30px; border-radius:9px; border:2.5px solid var(--ink); box-shadow:0 2px 0 var(--shadow);
+  display:flex; align-items:center; justify-content:center; font-family:var(--font-d); font-weight:700; font-size:13px; color:#fff; text-shadow:0 1px 0 rgba(44,39,51,.45); }
+.retire-card b{ font-family:var(--font-d); font-weight:600; font-size:10px; text-align:center; line-height:1.05; }
+.retire-card .ii{ position:absolute; top:-5px; right:-5px; font-family:var(--font-d); font-weight:700; font-size:8px;
+  color:#2c2733; background:#f0a92c; border:1.5px solid #2c2733; border-radius:6px; padding:0 3px; }
+.retire-actions{ display:flex; gap:8px; margin-top:9px; }
+.retire-actions .mk{ flex:1; height:42px; font-size:14px; }
+.retire-confirm{ background:#ef4a5a; color:#fffdf6; }
+.retire-confirm.dim{ opacity:.5; pointer-events:none; }
+/* reagent-chip II pip */
+.rgchip.ii{ position:relative; }
+.rgchip.ii::after{ content:"II"; position:absolute; top:-5px; right:-5px; font-family:var(--font-d); font-weight:700;
+  font-size:7.5px; line-height:1; color:#2c2733; background:#f0a92c; border:1.5px solid #2c2733; border-radius:5px; padding:1px 2px; }
+/* difficulty toggle on the start screen */
+.diffrow{ display:flex; align-items:center; gap:6px; margin-top:10px; }
+.diff-lbl{ font-family:var(--font-u); font-weight:800; font-size:9px; letter-spacing:.11em; text-transform:uppercase; color:var(--ink-soft); }
+.diffbtn{ flex:1; height:34px; font-size:13px; padding:0 6px; }
+
 /* ---------- NEXT WAVE readout (free intel — the Bazaar's scouting report) ---------- */
 .nextwave{ margin:2px 0 4px; padding:9px 10px 8px; background:var(--paper2);
   border:2.5px solid var(--ink); border-radius:15px; box-shadow:0 3px 0 var(--shadow); }
@@ -270,6 +325,12 @@ body{
       <button class="mk" id="btnStart" style="flex:1;height:52px;font-size:18px;">Turns</button>
       <button class="mk" id="btnFlow" style="flex:1;height:52px;font-size:18px;">Flow</button>
     </div>
+    <div class="diffrow" id="diffRow">
+      <span class="diff-lbl">Difficulty</span>
+      <button class="mk diffbtn" data-diff="gentle">Gentle</button>
+      <button class="mk diffbtn" data-diff="standard">Standard</button>
+      <button class="mk diffbtn" data-diff="fierce">Fierce</button>
+    </div>
     <div class="credit"><a href="/" title="İzge Bayyurt">İzge Bayyurt ↗</a></div>
   </div>
 </div>
@@ -288,6 +349,7 @@ body{
       <div class="shopsec">
         <div class="seclabel sale">For sale</div>
         <div class="cards" id="rwShop"></div>
+        <div class="retire-sec" id="rwRetire"></div>
       </div>
     </div>
     <div class="row"><button class="mk accent dim" id="btnContinue" style="flex:1;height:48px;font-size:16px;">Continue</button></div>
@@ -333,6 +395,19 @@ var CFG = {
   realtime: false,     // FLOW MODE: real-time variant (set by start-screen toggle)
   castCd: 2.2          // flow: base cast cooldown, seconds (Haste boon lowers it)
 };
+
+/* ===================== DIFFICULTY (selector plumbing) =====================
+   ONE multiplier table, applied in rollWave (enemy hp · wave count ceil · gate damage).
+   PLACEHOLDER values — the economist supplies finals; swapping the table is a one-line edit. */
+var DIFF = {
+  gentle:   { hp:0.75, count:0.80, dmg:0.75 },
+  standard: { hp:1.00, count:1.00, dmg:1.00 },
+  fierce:   { hp:1.25, count:1.10, dmg:1.25 }
+};
+var DIFF_LABEL = { gentle:"Gentle", standard:"Standard", fierce:"Fierce" };
+var difficulty = "standard";
+try{ var _wd=localStorage.getItem("wh_diff"); if(_wd&&DIFF[_wd]) difficulty=_wd; }catch(e){}
+function diffMul(){ return DIFF[difficulty] || DIFF.standard; }
 
 /* colours ---------------------------------------------------------------- */
 var HEX = { R:"#ef4a5a", Y:"#f6c445", B:"#3d8bdf", O:"#f2913d", G:"#57c268", P:"#9b62d6", H:"#b9b2a6", W:"#f4f0ff" };
@@ -415,6 +490,8 @@ function newGame(){
     gildNext:false,                                 // Gilding: next merge free + +1 level
     aurumSpent:false, firstTransmuteUsed:false,     // Aurum: once/wave · Catalyst: only 1st transmute/turn is free
     bazaarOffers:[], boonPicked:false,              // rolled at wave clear; boon locks per visit
+    tier2:{}, catFree:0,                             // MERGE→II ownership set + Catalyst free-transmute counter/turn
+    retireN:0, retireMode:false, retireSel:null,    // Retire slot: escalating fee count + UI mode/selection
     dialSig:"", exoticGlow:{}, masonFlash:0,        // strip-glow cache + Mason gate flourish
     // ---- FLOW MODE clocks (delta-accumulated; only advance while unpaused) ----
     cool:0, coolMax:CFG.castCd, coolPulse:0,        // cast cooldown
@@ -448,10 +525,11 @@ function alive(){ return S.enemies.filter(function(e){ return !e.dead; }); }
    (types, lanes, rungs, wards, hp, dmg) as plain data. No side effects, no DOM, no now(): the SAME
    spec drives both the Bazaar's NEXT-WAVE preview and the actual spawn, so they can never diverge. */
 function rollWave(w){
+  var D = diffMul();                       // difficulty multipliers (hp · count · dmg) — standard = identity
   var elite = (w>=8 && (w-8)%4===0);      // elite cadence: 8, 12, 16, 20...
-  var count = Math.min(9, 2 + w) - (elite?2:0);
+  var count = Math.min(9, Math.ceil((2 + w) * D.count)) - (elite?2:0);
   var wardChance = Math.min(0.75, 0.05 + w*0.10);
-  var baseDmg = 2 + Math.ceil(w/4);
+  var baseDmg = Math.max(1, Math.round((2 + Math.ceil(w/4)) * D.dmg));
   var spread = w>=5 ? 3 : 2;              // deeper spawn rungs from wave 5
   var used = {};
   var total = count + (elite?1:0);
@@ -477,6 +555,7 @@ function rollWave(w){
     var warded = !isElite && !brute && !armored && !leech && !isHealer && Math.random()<wardChance;
     var ward = (isElite||warded) ? ["O","G","P"][(Math.random()*3)|0] : null;
     var hp = isElite ? Math.round((16+8*w)*2.6) : brute ? (16+8*w) : (4+3*w);
+    hp = Math.max(1, Math.round(hp * D.hp));      // difficulty: enemy HP scaling
     list.push({
       lane:lane, rung:rung, hp:hp, maxhp:hp, ward:ward, brute:brute||isElite,
       elite:isElite, armored:armored, healer:isHealer, leech:leech,
@@ -496,7 +575,7 @@ function spawnWave(spec){
   st.lastSpell=null; st.repeatN=0;        // a new wave forgives old habits
   st.aurumSpent=false;                    // Aurum: rechargeable once per wave
   st.pyre=null;                           // Pyre Ground is wave-scoped (creations persist — they're monuments)
-  st.firstTransmuteUsed=false;            // Catalyst: first free transmute resets each wave/turn
+  st.firstTransmuteUsed=false; st.catFree=0;   // Catalyst: free transmute(s) reset each wave/turn
   spec.enemies.forEach(function(es,k){
     st.enemies.push({
       lane:es.lane, rung:es.rung, x:laneX(es.lane), y:rungY(es.rung),
@@ -511,7 +590,7 @@ function spawnWave(spec){
       beep(e.elite?150:300+e.lane*40, e.elite?.14:.06,"sine", e.elite?.06:.03);
     } }, delay); })(st.enemies[k], k*80);
   });
-  st.actions = st.maxActions = CFG.actions + CFG.maxActionsUp + (st.reagents.quicksilver?1:0);   // Quicksilver: +1/turn
+  st.actions = st.maxActions = CFG.actions + CFG.maxActionsUp + (st.reagents.quicksilver?(isII("quicksilver")?2:1):0);   // Quicksilver: +1/turn (II: +2)
   st.freeMerge = true;
   // FLOW: the beat tightens each wave — 4.0s at wave 1, -0.1s/wave, floor 2.5s
   st.beatMax = Math.max(2.5, 4.0 - (st.wave-1)*0.1);
@@ -721,6 +800,7 @@ function nearest(){
    opts.eclipsePierce → skip ward math only. */
 function applyDmg(e, amt, el, opts){
   opts = opts || {};
+  if(e.subl && amt>0) amt += 2;                    // Sublimate II: exposed foes take +2 from all sources this wave
   var trueDmg = opts.trueDamage, pierce = opts.eclipsePierce;
   if(!trueDmg){
     if(e.elite && opts.usedW) amt = Math.ceil(amt*0.65);
@@ -734,7 +814,7 @@ function applyDmg(e, amt, el, opts){
       return 0;                                    // plate bounced — no damage dealt
     }
   }
-  if(e.freeze>0 && S.reagents && S.reagents.shatterfrost) amt = Math.round(amt*1.5);   // Shatterfrost: +50% on the frozen
+  if(e.freeze>0 && S.reagents && S.reagents.shatterfrost) amt = Math.round(amt*(isII("shatterfrost")?2:1.5));   // Shatterfrost: +50% frozen (II: +100%)
   var crit = !trueDmg && !pierce && e.ward && el===e.ward;
   e.hp -= amt; e.hit = now();
   sHit(amt, crit);
@@ -745,10 +825,11 @@ function applyDmg(e, amt, el, opts){
     confetti(e.x,e.y, e.ward?HEX[e.ward]:"#cfc5b2");
     sDeath();
     addMotes(moteValue(e), e.x, e.y);                 // pigment motes fly to the coin chip
-    if(S.reagents.mold && e.poison>0){                // Creeping Mold: poison leaps to the nearest survivor
-      var near=null, bd=Infinity;
-      alive().forEach(function(x){ var dd=Math.hypot(x.x-e.x,x.y-e.y); if(dd<bd){ bd=dd; near=x; } });
-      if(near){ near.poison = Math.min(POISON_CAP, near.poison + e.poison); near.dotT=now(); spawnDmg(near.x, near.y-geo.ballR*0.9, e.poison, false, false, true); }
+    if(S.reagents.mold && e.poison>0){                // Creeping Mold: poison leaps from the slain (II: to the TWO nearest, split)
+      var sorted=alive().slice().sort(function(a,b){ return Math.hypot(a.x-e.x,a.y-e.y)-Math.hypot(b.x-e.x,b.y-e.y); });
+      var ii=isII("mold"), targets=sorted.slice(0, ii?2:1), share=ii?Math.ceil(e.poison/2):e.poison;
+      targets.forEach(function(near){ near.poison=Math.min(POISON_CAP, near.poison+share); near.dotT=now();
+        spawnDmg(near.x, near.y-geo.ballR*0.9, share, false, false, true); });
     }
   } else if(e.healer && !e.dead){
     // SKITTISH: a healer that survives a hit bolts one rung deeper and spends its next
@@ -794,7 +875,7 @@ function applyStale(st, sp){
   }
 }
 /* burn application funnels through here so Cinder Wick can stretch every ignition by a tick */
-function applyBurn(e, val){ e.burn = Math.max(e.burn, val + (S.reagents && S.reagents.cinder?1:0)); }
+function applyBurn(e, val){ e.burn = Math.max(e.burn, val + (S.reagents && S.reagents.cinder ? (isII("cinder")?2:1) : 0)); }   // Cinder Wick: +1 tick (II: +2)
 /* poison stacks are capped so doubling/jumps can't runaway */
 var POISON_CAP = 12;
 
@@ -900,7 +981,8 @@ function transmuteFx(slot){
 function transmute(idxs){
   var st=S;
   // Catalyst waives the action only for the FIRST transmute each turn (Turns); after that it costs normally
-  var freeCat = !CFG.realtime && st.reagents.catalyst && !st.firstTransmuteUsed;
+  var catCap = isII("catalyst") ? 2 : 1;                                    // II: first TWO transmutes/turn are free
+  var freeCat = !CFG.realtime && st.reagents.catalyst && (st.catFree||0) < catCap;
   if(!CFG.realtime && !freeCat && st.actions<=0) return;   // Turns: needs a spare action
   st.busy=true; st.phase="cast";
   idxs.forEach(function(i,k){ st.dial[i].castT=now()+k*40; });   // fuse: the three are drunk together
@@ -912,7 +994,7 @@ function transmute(idxs){
   },150);
   setTimeout(function(){ if(S!==st||st.over) return;
     idxs.forEach(function(i,k){
-      if(i===mid) st.dial[i] = { c:"W", lvl:(st.reagents.lens?2:1), born:now() };   // Lens mints Prisms at L2
+      if(i===mid) st.dial[i] = { c:"W", lvl:(st.reagents.lens?(isII("lens")?3:2):1), born:now() };   // Lens mints Prisms at L2
       else { st.dial[i]=freshBall(); st.dial[i].born=now()+k*40; }
     });
     recordSpell({ name:"Prism", fizzle:false, tint:HEX.W }, false);     // Prism is discoverable
@@ -920,7 +1002,7 @@ function transmute(idxs){
   setTimeout(function(){ if(S!==st||st.over) return;
     st.phase=null; st.busy=false;
     if(CFG.realtime){ if(alive().length===0) setTimeout(waveClear, 300); }   // craft: no cooldown, no action
-    else if(freeCat){ st.firstTransmuteUsed=true; if(alive().length===0) setTimeout(waveClear, 300); }   // Catalyst: 1st/turn is free
+    else if(freeCat){ st.catFree=(st.catFree||0)+1; st.firstTransmuteUsed=true; if(alive().length===0) setTimeout(waveClear, 300); }   // Catalyst: free transmute (II: up to 2/turn)
     else spend();                                                            // Turns: costs one action
   },400);
 }
@@ -965,7 +1047,7 @@ function castWeave(idxs){
     else { sCast(spA.tl, spA.whorl); castFx(spA, aimA.tgt, aimA.hits.map(hitPt)); }
   },150);
   setTimeout(function(){ if(S!==st||st.over) return;
-    if(spA.transmute){ st.dial[idxs[1]]={ c:"W", lvl:(st.reagents.lens?2:1), born:now() }; minted[idxs[1]]=true;
+    if(spA.transmute){ st.dial[idxs[1]]={ c:"W", lvl:(st.reagents.lens?(isII("lens")?3:2):1), born:now() }; minted[idxs[1]]=true;
       recordSpell({ name:"Prism", fizzle:false, tint:HEX.W }, true); }
     else { impactSpell(spA, aimA.hits); recordSpell(spA, true); }
     S.shake += 5;                                            // doublecast spectacle
@@ -976,7 +1058,7 @@ function castWeave(idxs){
     else { aimB=aimSpell(spB); sCast(spB.tl, true); castFx(spB, aimB.tgt, aimB.hits.map(hitPt)); }
   },350);
   setTimeout(function(){ if(S!==st||st.over) return;
-    if(spB.transmute){ st.dial[idxs[4]]={ c:"W", lvl:(st.reagents.lens?2:1), born:now() }; minted[idxs[4]]=true;
+    if(spB.transmute){ st.dial[idxs[4]]={ c:"W", lvl:(st.reagents.lens?(isII("lens")?3:2):1), born:now() }; minted[idxs[4]]=true;
       recordSpell({ name:"Prism", fizzle:false, tint:HEX.W }, true); }
     else { impactSpell(spB, aimB.hits); recordSpell(spB, true); }
   },430);
@@ -1024,43 +1106,47 @@ function weaveCollapse(idxs, balls){
 var EXOTIC = [
   { key:"quench", name:"Quench", recipe:["B","R","R","B"], price:22, bg:"#3d8bdf", dmg:true,
     desc:"Consume all burn on the field; each burned foe takes 3× its ticks as damage.",
-    cast:function(st,TL,mul){ var any=false;
-      alive().slice().forEach(function(e){ if(e.burn>0){ var tk=e.burn; e.burn=0; applyDmg(e, Math.max(1,Math.round(tk*3*mul)), "O"); any=true; } });
+    cast:function(st,TL,mul){ var any=false, qm=isII("Quench")?4:3;                       // II: consumed burn pays 4× (was 3×)
+      alive().slice().forEach(function(e){ if(e.burn>0){ var tk=e.burn; e.burn=0; applyDmg(e, Math.max(1,Math.round(tk*qm*mul)), "O"); any=true; } });
       boom(geo.cx, geo.gateY-30, HEX.O, 1.5); if(any) sHit(9,true); } },
   { key:"mordant", name:"Mordant", recipe:["R","B","B","R"], price:24, bg:"#9b62d6",
     desc:"Your next TWO casts each fire twice — both hits at full power.",
-    cast:function(st){ st.pendingDouble=2; st.pendingDoubleT=now(); sChime(); } },
+    cast:function(st){ st.pendingDouble=(isII("Mordant")?3:2); st.pendingDoubleT=now(); sChime(); } },   // II: next THREE casts doubled
   { key:"undertow", name:"Undertow", recipe:["B","Y","Y","B"], price:25, bg:"#3d8bdf",
     desc:"Shove every foe back one rung; wall-huggers are washed off entirely.",
-    cast:function(st){ alive().slice().forEach(function(e){
-        if(e.rung<=0){ e.dead=true; e.deadAt=now(); boom(e.x,e.y,HEX.B,1.1); }
-        else { e.rung=Math.min(CFG.rungs-1, e.rung+1); e.stepT=now(); } });
+    cast:function(st){ var push=isII("Undertow")?2:1;                                     // II: shove 2 rungs
+      alive().slice().forEach(function(e){
+        if(e.rung < push){ e.dead=true; e.deadAt=now(); boom(e.x,e.y,HEX.B,1.1); }
+        else { e.rung=Math.min(CFG.rungs-1, e.rung+push); e.stepT=now(); } });
       S.fx.push({ wave:true, t:now(), tint:HEX.B }); } },
   { key:"ferment", name:"Ferment", recipe:["Y","B","Y","B","Y"], price:22, bg:"#57c268",
     desc:"Double every poison stack on every foe (capped at 12).",
-    cast:function(st){ alive().forEach(function(e){ if(e.poison>0){ e.poison=Math.min(POISON_CAP, Math.round(e.poison*2)); e.dotT=now(); } }); sHit(6,false); } },
+    cast:function(st){ var flat=isII("Ferment")?2:0;                                       // II: +2 flat poison to all as well
+      alive().forEach(function(e){ if(e.poison>0){ e.poison=Math.round(e.poison*2); } e.poison=Math.min(POISON_CAP, e.poison+flat); if(e.poison>0) e.dotT=now(); }); sHit(6,false); } },
   { key:"gilding", name:"Gilding", recipe:["Y","R","R","Y"], price:20, bg:"#f6c445",
     desc:"Your next merge is free and its result gains +1 level.",
     cast:function(st){ st.gildNext=true; S.fx.push({ star:true, x:geo.cx, y:geo.cy, t:now(), tint:"#ffd15c" }); } },
   { key:"calcine", name:"Calcine", recipe:["R","R","Y","R","R"], price:24, bg:"#f2913d", dmg:true,
     desc:"Scour the target lane: heavy fire damage plus a deep burn to everything in it.",
     cast:function(st,TL,mul){ var tgt=nearest(); if(!tgt) return;
-      var dmg=Math.max(1,Math.round(5*TL*CFG.spellPow*mul));
+      var dmg=Math.max(1,Math.round((isII("Calcine")?7:5)*TL*CFG.spellPow*mul));           // II: lane coeff 7 (was 5)
       alive().slice().forEach(function(e){ if(e.lane===tgt.lane){ applyDmg(e,dmg,"O"); applyBurn(e,3); } });
       S.fx.push({ laneFlash:true, lane:tgt.lane, t:now(), tint:HEX.O }); } },
   { key:"distill", name:"Distill", recipe:["Y","B","B","Y"], price:20, bg:"#3d8bdf",
     desc:"Purge every husk on the dial — fresh primaries take their slots.",
-    cast:function(st){ for(var i=0;i<CFG.slots;i++){ if(st.dial[i] && st.dial[i].c==="H"){ st.dial[i]=freshBall(); st.dial[i].born=now(); var gs=geo.slots[i]; boom(gs.x,gs.y,"#ffffff",0.9); } } } },
+    cast:function(st){ var purged=0; for(var i=0;i<CFG.slots;i++){ if(st.dial[i] && st.dial[i].c==="H"){ st.dial[i]=freshBall(); st.dial[i].born=now(); var gs=geo.slots[i]; boom(gs.x,gs.y,"#ffffff",0.9); purged++; } }
+      if(isII("Distill") && purged>0) addMotes(2*purged, geo.cx, geo.cy-geo.dialR-geo.ballR); } },   // II: +2 motes per husk purged
   { key:"sublimate", name:"Sublimate", recipe:["B","R","B","R","B"], price:20, bg:"#9b62d6",
     desc:"Shatter the ward from every warded foe this wave.",
-    cast:function(st){ alive().forEach(function(e){ if(e.ward){ var c=HEX[e.ward]; e.ward=null; boom(e.x,e.y,c,1.4); confetti(e.x,e.y,c); } }); sChime(); } },
+    cast:function(st){ var ii=isII("Sublimate"); alive().forEach(function(e){ if(e.ward){ var c=HEX[e.ward]; e.ward=null; if(ii) e.subl=true; boom(e.x,e.y,c,1.4); confetti(e.x,e.y,c); } }); sChime(); } },   // II: stripped foes take +2 from all sources this wave
   { key:"bellows", name:"Bellows", recipe:["R","Y","Y","R"], price:24, bg:"#f2913d", dmg:true,
     desc:"Every burn tick fires at once at 2×; the burn is then spent.",
-    cast:function(st,TL,mul){ alive().slice().forEach(function(e){ if(e.burn>0){ var tk=e.burn; e.burn=0; applyDmg(e, Math.max(1,Math.round(tk*4*mul)), "O"); } });
+    cast:function(st,TL,mul){ var bm=isII("Bellows")?6:4;                                  // II: detonate at 3× (was 2×)
+      alive().slice().forEach(function(e){ if(e.burn>0){ var tk=e.burn; e.burn=0; applyDmg(e, Math.max(1,Math.round(tk*bm*mul)), "O"); } });
       boom(geo.cx, geo.gateY-30, HEX.O, 1.7); } },
   { key:"aurum", name:"Aurum", recipe:["Y","Y","R","Y","Y"], price:21, bg:"#f6c445",
     desc:"Once per wave: transmute the horde's light into coin — 2 motes per living foe.",
-    cast:function(st){ var n=alive().length; if(n>0) addMotes(2*n, geo.cx, geo.cy-geo.dialR-geo.ballR); st.aurumSpent=true; sChime(); } }
+    cast:function(st){ var n=alive().length; if(n>0) addMotes((isII("Aurum")?3:2)*n, geo.cx, geo.cy-geo.dialR-geo.ballR); st.aurumSpent=true; sChime(); } }   // II: 3 motes/foe
 ];
 var EXOTIC_BY_NAME={}; EXOTIC.forEach(function(x){ EXOTIC_BY_NAME[x.name]=x; });
 /* the swept colours (in sweep order) vs owned recipes — exact, order-sensitive; any W = no match */
@@ -1220,11 +1306,15 @@ var CREATION_LOOK = {
   beacon:   { fill:"#a48fc6", fill2:"#7c67a4", cap:"#ffd15c", label:"Beacon",   big:true,  tint:"#b18be0" }
 };
 function creationTint(kind){ return (CREATION_LOOK[kind]||{}).tint || "#a38661"; }
+var KIND_RITUAL = { golem:"Golem", colossus:"Colossus", sentry:"Sentry", beacon:"Beacon" };   // creation kind → owning ritual
 function creationStats(kind, TL){
-  if(kind==="colossus") return { hp:7*TL, attack:TL };
-  if(kind==="sentry")   return { hp:3*TL, attack:Math.ceil(TL*0.75) };
-  if(kind==="beacon")   return { hp:4*TL, attack:Math.ceil(TL*0.6) };
-  return { hp:4*TL, attack:Math.ceil(TL/2) };                 // golem
+  var s;
+  if(kind==="colossus") s={ hp:7*TL, attack:TL };
+  else if(kind==="sentry")   s={ hp:3*TL, attack:Math.ceil(TL*0.75) };
+  else if(kind==="beacon")   s={ hp:4*TL, attack:Math.ceil(TL*0.6) };
+  else s={ hp:4*TL, attack:Math.ceil(TL/2) };                 // golem
+  if(isII(KIND_RITUAL[kind])){ s.hp=Math.ceil(s.hp*1.5); s.attack=Math.ceil(s.attack*1.5); }   // Ritual II: creation +50%
+  return s;
 }
 function liveCreations(){ return S.creations.filter(function(c){ return !c.dead; }); }
 function creationAt(lane, rung){
@@ -1345,7 +1435,7 @@ function creationAct(c){
 /* ---------- Pyre Ground: a wave-scoped burning zone on a lane's middle rung (rung 2) ---------- */
 function layPyre(st, TL){
   var lane=pickThreatLane(null);
-  st.pyre={ lane:lane, rung:2, t:now(), TL:TL };
+  st.pyre={ lane:lane, rung:2, t:now(), TL:TL, ii:isII("Pyre Ground") };   // II: damage 3 + burn 3
   var px=laneX(lane), py=rungY(2);
   boom(px, py, HEX.O, 1.8); confetti(px, py, HEX.O);
   S.fx.push({ laneFlash:true, lane:lane, t:now(), tint:HEX.O });
@@ -1353,11 +1443,12 @@ function layPyre(st, TL){
 }
 function applyPyre(e){
   if(!S.pyre || e.dead) return;
-  if(e.lane===S.pyre.lane && e.rung===S.pyre.rung){ applyDmg(e, 2, "O"); applyBurn(e, 2); }
+  if(e.lane===S.pyre.lane && e.rung===S.pyre.rung){ var pv=S.pyre.ii?3:2; applyDmg(e, pv, "O"); applyBurn(e, pv); }
 }
 /* ---------- Bastion: instant wall re-lay ---------- */
 function raiseBastion(st, TL){
-  st.maxhp+=4; st.hp=Math.min(st.maxhp, st.hp+8);
+  var ii=isII("Bastion");                                     // II: +12 HP now / +6 max
+  st.maxhp+=(ii?6:4); st.hp=Math.min(st.maxhp, st.hp+(ii?12:8));
   st.masonFlash=now();                                        // reuse the gate re-lay flourish (staggered blocks)
   boom(geo.cx, geo.gateY, "#ffd15c", 2.0);
   confetti(geo.cx, geo.gateY, "#ffd15c");
@@ -1413,7 +1504,7 @@ function postAction(){
 }
 /* FLOW: casting on cooldown — soft reject, no penalty, no balls consumed.
    Quicksilver shaves 12% off the cast cooldown. */
-function effCastCd(){ return CFG.castCd * (S && S.reagents.quicksilver ? 0.88 : 1); }
+function effCastCd(){ return CFG.castCd * (S && S.reagents.quicksilver ? (isII("quicksilver")?0.76:0.88) : 1); }   // Quicksilver: −12% cd (II: −24%)
 /* FLOW CHAINING: casting within CHAIN_WINDOW of the spiral becoming ready shaves the NEXT cooldown
    CHAIN_STEP per consecutive prompt cast (stacking to CHAIN_MAX), floored at CHAIN_FLOOR seconds.
    Multiplicative with Haste + Quicksilver (both baked into effCastCd). Idling resets the chain. */
@@ -1507,7 +1598,7 @@ function dotTick(e){
   if(e.dead) return;
   e.dotT = now();
   if(e.poison>0){ applyDmg(e, Math.max(1,Math.round(e.poison)), "G"); e.poison--; }
-  if(e.burn>0){ applyDmg(e, (S.reagents && S.reagents.cinder)?3:2, "O"); e.burn--; }   // Cinder Wick: hotter ticks (3 vs 2)
+  if(e.burn>0){ applyDmg(e, (S.reagents && S.reagents.cinder) ? (isII("cinder")?4:3) : 2, "O"); e.burn--; }   // Cinder Wick: hotter ticks (3, II 4, vs 2)
 }
 function stepEnemy(e){
   if(e.dead) return;
@@ -1544,7 +1635,7 @@ function endEnemyPhase(){
   if(!CFG.realtime){
     st.actions = st.maxActions;
     st.freeMerge = true;
-    st.firstTransmuteUsed = false;   // Catalyst: a new turn re-arms the free transmute
+    st.firstTransmuteUsed = false; st.catFree = 0;   // Catalyst: a new turn re-arms the free transmute(s)
     st.busy=false;
   }
   st.phase=null;
@@ -1557,7 +1648,7 @@ function waveClear(){
   S.busy=true; S.phase="clear";
   if(S.stats) S.stats.waves++;                 // held one more wave — death readout
 
-  if(S.reagents.mason){ S.hp=Math.min(S.maxhp, S.hp+1); S.masonFlash=now(); syncHud(); }   // Mason re-lays a block
+  if(S.reagents.mason){ S.hp=Math.min(S.maxhp, S.hp+(isII("mason")?2:1)); S.masonFlash=now(); syncHud(); }   // Mason re-lays a block (II: +2/wave)
   sWin(); vib(20);
   toast("WAVE CLEAR!", 850, "#2c2733", "mid", true);
   boom(geo.cx, geo.cy-geo.dialR-geo.ballR, "#ffd15c", 2);
@@ -1603,7 +1694,7 @@ var PRICE_FLOOR = 20;
 function applyReagent(key){
   S.reagents[key]=true;
   if(key==="buttress"){ S.maxhp+=8; S.hp+=8; syncHud(); }
-  if(key==="quicksilver"){ S.maxActions=CFG.actions+CFG.maxActionsUp+1; S.actions=Math.min(S.maxActions,S.actions+1); syncHud(); }
+  if(key==="quicksilver"){ S.maxActions=CFG.actions+CFG.maxActionsUp+(isII("quicksilver")?2:1); S.actions=Math.min(S.maxActions,S.actions+1); syncHud(); }
   renderReagentBar();
 }
 function renderReagentBar(){
@@ -1613,77 +1704,316 @@ function renderReagentBar(){
   REAGENT.forEach(function(r){
     if(!S.reagents[r.key]) return;
     var chip=document.createElement("div");
-    chip.className="rgchip"; chip.style.background=r.bg; chip.textContent=r.ic; chip.title=r.name;
+    chip.className="rgchip"+(isII(r.key)?" ii":""); chip.style.background=r.bg; chip.textContent=r.ic; chip.title=r.name+(isII(r.key)?" II":"");
     chip.addEventListener("click", function(){
-      S.hubInfo={ l1:r.name, l2:reagentDesc(r), l3:"reagent · lasts this run", col:r.bg, until:now()+1600 };
+      S.hubInfo={ l1:r.name+(isII(r.key)?" · II":""), l2:reagentDesc(r), l3:isII(r.key)?"reagent II · upgraded":"reagent · lasts this run", col:r.bg, until:now()+1600 };
       beep(560,.06,"sine",.035);
     });
     bar.appendChild(chip);
   });
 }
 
+/* ===================== rarity tiers + build tags (Bazaar excitement pass) =====================
+   Every purchasable carries a rarity (wave-gated) and build tags (owning a tag doubles same-tag roll
+   weight). Sigils/rituals are keyed by NAME, reagents by KEY — none collide, so ITEM_META is one map
+   and S.tier2 (the MERGE→II ownership set) shares the same id space. */
+var RARITY = { common:{ word:"Common", border:"#2c2733" }, rare:{ word:"Rare", border:"#f0a92c" }, epic:{ word:"Epic", border:"#9b62d6" } };
+var ITEM_META = {
+  /* sigils (by name) */
+  Gilding:{r:"common",t:["weave"]}, Distill:{r:"common",t:["weave"]}, Aurum:{r:"common",t:["economy"]}, Sublimate:{r:"common",t:["weave"]},
+  Quench:{r:"rare",t:["burn"]}, Bellows:{r:"rare",t:["burn"]}, Undertow:{r:"rare",t:["wall"]}, Ferment:{r:"rare",t:["poison"]},
+  Mordant:{r:"epic",t:["weave"]}, Calcine:{r:"epic",t:["burn"]},
+  /* rituals (by name) */
+  Golem:{r:"rare",t:["summon"]}, Sentry:{r:"rare",t:["summon"]}, "Pyre Ground":{r:"rare",t:["burn"]},
+  Colossus:{r:"epic",t:["summon"]}, Beacon:{r:"epic",t:["summon"]}, Bastion:{r:"epic",t:["wall"]},
+  /* reagents (by key) */
+  buttress:{r:"common",t:["wall"]}, catalyst:{r:"common",t:["economy"]}, mason:{r:"common",t:["wall"]},
+  cinder:{r:"rare",t:["burn"]}, shatterfrost:{r:"rare",t:["freeze"]}, lens:{r:"rare",t:["economy"]},
+  quicksilver:{r:"epic",t:["weave"]}, mold:{r:"epic",t:["poison"]}
+};
+/* concise tier-II upgrade blurbs — shown on a MERGE→II offer so the player knows what the merge buys */
+var II_DESC = {
+  Quench:"II: consumed burn pays 4× (was 3×)", Mordant:"II: your next THREE casts doubled", Undertow:"II: shove 2 rungs back",
+  Ferment:"II: ×2 poison AND +2 flat to all", Gilding:"II: free merge grants +2 levels", Calcine:"II: lane coefficient 7",
+  Distill:"II: purge husks + 2 motes per husk", Sublimate:"II: stripped foes take +2 from all sources",
+  Bellows:"II: detonate all burn at 3×", Aurum:"II: 3 motes per living foe",
+  Golem:"II: golem +50% HP & attack", Sentry:"II: sentry +50% HP & attack", "Pyre Ground":"II: damage 3 + burn 3",
+  Colossus:"II: colossus +50% HP & attack", Beacon:"II: beacon +50% HP & attack", Bastion:"II: +12 HP now / +6 max",
+  cinder:"II: burn ticks 4 dmg, +2 duration", shatterfrost:"II: frozen foes take +100%", lens:"II: minted Prisms at L3",
+  quicksilver:"II: +2 actions / −24% cooldown", mold:"II: poison jumps to the TWO nearest",
+  buttress:"II: +8 more max HP (16 total)", mason:"II: +2 wall HP per wave clear", catalyst:"II: first TWO transmutes free"
+};
+function metaOf(id){ return ITEM_META[id] || { r:"common", t:[] }; }
+function rarityOf(id){ return metaOf(id).r; }
+function tagsOf(id){ return metaOf(id).t; }
+/* rarity gates: common always; rare from wave 4; epic from wave 8 */
+function itemLegal(rar, wave){ if(rar==="rare") return wave>=4; if(rar==="epic") return wave>=8; return true; }
+/* roll weight by rarity + wave: wave 4-7 rare==common (epic locked); wave 8+ rare 1.5×, epic 1× */
+function rarityWeight(rar, wave){
+  if(rar==="rare") return wave>=4 ? (wave>=8?1.5:1) : 0;
+  if(rar==="epic") return wave>=8 ? 1 : 0;
+  return 1;   // common
+}
+/* MERGE→II: tier-II ownership set (id-keyed like ITEM_META) */
+function isII(id){ return !!(S && S.tier2 && S.tier2[id]); }
+/* the tags the player already owns — a same-tag candidate rolls at 2× */
+function ownedTagSet(){
+  var set={};
+  S.exotics.forEach(function(n){ tagsOf(n).forEach(function(t){ set[t]=1; }); });
+  S.rituals.forEach(function(n){ tagsOf(n).forEach(function(t){ set[t]=1; }); });
+  REAGENT.forEach(function(r){ if(S.reagents[r.key]) tagsOf(r.key).forEach(function(t){ set[t]=1; }); });
+  return set;
+}
+function tagMult(id, ownedTags){ var t=tagsOf(id); for(var i=0;i<t.length;i++){ if(ownedTags[t[i]]) return 2; } return 1; }
+function weightedPick(cands){
+  var tot=0; cands.forEach(function(c){ tot+=c.w; });
+  if(tot<=0) return null;
+  var r=Math.random()*tot;
+  for(var i=0;i<cands.length;i++){ r-=cands[i].w; if(r<=0) return cands[i]; }
+  return cands[cands.length-1];
+}
+
 /* ===================== the Bazaar ===================== */
 function shuffle(a){ for(var i=a.length-1;i>0;i--){ var j=(Math.random()*(i+1))|0, t=a[i]; a[i]=a[j]; a[j]=t; } return a; }
-function makeExoticOffer(ex){ return { type:"exotic", key:ex.key, name:ex.name, price:ex.price, desc:ex.desc, bg:ex.bg, recipe:ex.recipe, sold:false }; }
-function makeRitualOffer(ri){ return { type:"ritual", key:ri.key, name:ri.name, price:ri.price, desc:ri.desc, bg:ri.bg, recipe:ri.recipe, sold:false }; }
-function makeReagentOffer(r){ return { type:"reagent", key:r.key, name:r.name, price:reagentPrice(r), desc:reagentDesc(r), bg:r.bg, recommended:!!r.recommended, sold:false }; }
 /* the arcane slots (sigils + rituals) share one 3-item cap */
 function arcaneOwned(){ return S.exotics.length + S.rituals.length; }
-/* roll three priced offers: 1 SIGIL + 1 RITUAL + 1 REAGENT, no dupes of what's owned. When the shared
-   3-slot arcane cap is full the shelf turns to all reagents. Short pools fall back to whatever's left. */
+/* build ONE offer object from an item def. cls: 'sigil'|'ritual'|'reagent'. merge → dupe of an owned
+   tier-I item, priced at 75% of base (the 20-mote floor is base-only, so merges may dip below). */
+function offerFor(def, cls, merge){
+  var id = cls==="reagent" ? def.key : def.name;
+  var base = cls==="reagent" ? reagentPrice(def) : def.price;
+  var price = merge ? Math.round(base*0.75) : base;
+  return { type: cls==="sigil"?"exotic":cls, key:def.key, name:def.name, price:price, basePrice:base,
+    desc: cls==="reagent"?reagentDesc(def):def.desc, bg:def.bg, recipe:def.recipe,
+    recommended: cls==="reagent" && !!def.recommended && !merge,
+    rarity: rarityOf(id), tags: tagsOf(id).slice(), merge: !!merge, sold:false };
+}
+function makePackOffer(){ return { type:"pack", name:"Arcane Pack", price:28, rarity:"pack", bg:"#f0a92c", sold:false, pack:null }; }
+/* per-class candidate pool: unowned rarity-legal items (NEW offers, cap-gated for arcane) + owned
+   tier-I items (MERGE offers, cap-free). Tier-II items never appear. Each carries a roll weight. */
+function candsFor(cls, ownedTags){
+  var defs = cls==="sigil"?EXOTIC : cls==="ritual"?RITUAL : REAGENT;
+  var capFull = arcaneOwned()>=3, out=[];
+  defs.forEach(function(def){
+    var id = cls==="reagent"?def.key:def.name;
+    var owned = cls==="sigil" ? S.exotics.indexOf(id)>=0 : cls==="ritual" ? S.rituals.indexOf(id)>=0 : !!S.reagents[id];
+    if(isII(id)) return;                                          // tier II drops out of the pool entirely
+    if(owned){
+      out.push({ def:def, cls:cls, id:id, merge:true, w:Math.max(1, rarityWeight(rarityOf(id),S.wave))*tagMult(id,ownedTags) });
+    } else {
+      if(!itemLegal(rarityOf(id), S.wave)) return;               // rarity gate on NEW offers
+      if((cls==="sigil"||cls==="ritual") && capFull) return;     // no new arcane at the shared cap
+      out.push({ def:def, cls:cls, id:id, merge:false, w:rarityWeight(rarityOf(id),S.wave)*tagMult(id,ownedTags) });
+    }
+  });
+  return out;
+}
+/* roll the shelf: SIGIL slot (or an ARCANE PACK on pack waves) + RITUAL slot (falls back to a common
+   sigil/reagent before wave 4, when no ritual is legal) + REAGENT slot (Catalyst pity waves 1-6),
+   backfilled to three. Rolls are rarity-gated + build-weighted (owning a tag → 2× same-tag). */
 function rollBazaar(){
-  var offers=[];
-  var exAvail=shuffle(EXOTIC.filter(function(x){ return S.exotics.indexOf(x.name)<0; }));
-  var riAvail=shuffle(RITUAL.filter(function(x){ return S.rituals.indexOf(x.name)<0; }));
-  var rgAvail=shuffle(REAGENT.filter(function(x){ return !S.reagents[x.key]; }));
-  // THE CASUAL MERCY: pity-pin Catalyst into the reagent slot on waves 1-6 until the player owns it
-  if(S.wave<=6 && !S.reagents.catalyst){
-    var ci=-1; for(var q=0;q<rgAvail.length;q++){ if(rgAvail[q].key==="catalyst"){ ci=q; break; } }
-    if(ci>=0){ var cat=rgAvail.splice(ci,1)[0]; rgAvail.unshift(cat); }
+  var offers=[], used=[], ownedTags=ownedTagSet();
+  var isPackWave = (S.wave%3===0);
+  function pickFrom(cands){
+    var pool=cands.filter(function(c){ return used.indexOf(c.id)<0 && c.w>0; });
+    var pk=weightedPick(pool); if(!pk) return null;
+    used.push(pk.id); return offerFor(pk.def, pk.cls, pk.merge);
   }
-  var room = 3 - arcaneOwned();                              // how many arcane items may still be sold
-  if(room>0 && exAvail.length){ offers.push(makeExoticOffer(exAvail.shift())); room--; }   // 1 sigil
-  if(room>0 && riAvail.length){ offers.push(makeRitualOffer(riAvail.shift())); room--; }    // 1 ritual
-  while(offers.length<3 && rgAvail.length) offers.push(makeReagentOffer(rgAvail.shift()));  // reagent slot(s)
-  // backfill a thin shelf: more arcane within the shared cap, then whatever remains
-  while(offers.length<3 && room>0 && exAvail.length){ offers.push(makeExoticOffer(exAvail.shift())); room--; }
-  while(offers.length<3 && room>0 && riAvail.length){ offers.push(makeRitualOffer(riAvail.shift())); room--; }
+  // SIGIL slot — replaced by the Arcane Pack every 3rd Bazaar
+  if(isPackWave){ offers.push(makePackOffer()); }
+  else { var so=pickFrom(candsFor("sigil",ownedTags)); if(so) offers.push(so); }
+  // RITUAL slot — pre-wave-4 no ritual is legal, so substitute a common sigil/reagent
+  var ro=pickFrom(candsFor("ritual",ownedTags));
+  if(ro){ offers.push(ro); }
+  else {
+    var fb=candsFor("sigil",ownedTags).concat(candsFor("reagent",ownedTags)).filter(function(c){ return used.indexOf(c.id)<0 && c.w>0; });
+    var pk=weightedPick(fb); if(pk){ used.push(pk.id); offers.push(offerFor(pk.def,pk.cls,pk.merge)); }
+  }
+  // REAGENT slot — THE CASUAL MERCY: pity-pin Catalyst on waves 1-6 until owned
+  var rgCands=candsFor("reagent",ownedTags), pity=null;
+  if(S.wave<=6 && !S.reagents.catalyst){
+    for(var i=0;i<rgCands.length;i++){ if(rgCands[i].id==="catalyst" && used.indexOf("catalyst")<0){ pity=rgCands[i]; break; } }
+  }
+  if(pity){ used.push("catalyst"); offers.push(offerFor(pity.def,"reagent",false)); }
+  else { var rgo=pickFrom(rgCands); if(rgo) offers.push(rgo); }
+  // backfill a thin shelf from anything still eligible
+  var all=candsFor("sigil",ownedTags).concat(candsFor("ritual",ownedTags)).concat(candsFor("reagent",ownedTags));
+  var guard=0;
+  while(offers.length<3 && guard++<24){
+    var pool=all.filter(function(c){ return used.indexOf(c.id)<0 && c.w>0; });
+    var pk2=weightedPick(pool); if(!pk2) break;
+    used.push(pk2.id); offers.push(offerFor(pk2.def,pk2.cls,pk2.merge));
+  }
   S.bazaarOffers=offers;
 }
-function buyOffer(o){
-  if(o.sold || S.motes<o.price) return;
-  S.motes-=o.price; moteHudSet();
-  o.sold=true;
+/* grant a NEW arcanum/reagent (from a base buy or a pack pick) */
+function grantItem(o){
   if(o.type==="exotic"){ if(S.exotics.indexOf(o.name)<0 && arcaneOwned()<3) S.exotics.push(o.name); S.dialSig=""; }
   else if(o.type==="ritual"){ if(S.rituals.indexOf(o.name)<0 && arcaneOwned()<3) S.rituals.push(o.name); S.dialSig=""; }
   else applyReagent(o.key);
+}
+/* MERGE→II: flag tier II + settle any "now" effects that only fire on the upgrade */
+function applyMerge(o){
+  var id = o.type==="reagent"?o.key:o.name;
+  S.tier2[id]=true;
+  if(id==="buttress"){ S.maxhp+=8; S.hp+=8; syncHud(); }                                   // +8 more max (16 total)
+  else if(id==="quicksilver"){ S.maxActions=CFG.actions+CFG.maxActionsUp+2; S.actions=Math.min(S.maxActions,S.actions+1); syncHud(); }
+  S.dialSig=""; renderReagentBar();
+}
+function buyOffer(o){
+  if(o.type==="pack"){ buyPack(o); return; }
+  if(o.sold || S.motes<o.price) return;
+  S.motes-=o.price; moteHudSet();
+  o.sold=true;
+  if(o.merge) applyMerge(o);
+  else grantItem(o);
   sBoon(); vib(15);
   renderShop();   // re-price the rest of the stall against the lighter purse
+}
+/* ---------- the ARCANE PACK (Balatro mini-draft): buy → pick 1 of 3, others vanish ---------- */
+function rollPackChoices(){
+  var capFull=arcaneOwned()>=3, pool=[];
+  function add(defs, cls){
+    defs.forEach(function(def){
+      var id=cls==="reagent"?def.key:def.name;
+      var owned = cls==="sigil"?S.exotics.indexOf(id)>=0:cls==="ritual"?S.rituals.indexOf(id)>=0:!!S.reagents[id];
+      if(owned||isII(id)) return;
+      if(!itemLegal(rarityOf(id),S.wave)) return;
+      if((cls==="sigil"||cls==="ritual")&&capFull) return;
+      pool.push({def:def,cls:cls});
+    });
+  }
+  add(EXOTIC,"sigil"); add(RITUAL,"ritual"); add(REAGENT,"reagent");
+  shuffle(pool);
+  return pool.slice(0,3).map(function(c){ return offerFor(c.def,c.cls,false); });
+}
+function buyPack(o){
+  if(o.sold || S.motes<o.price) return;
+  S.motes-=o.price; moteHudSet();
+  o.sold=true;
+  o.pack={ choices:rollPackChoices(), picked:false };
+  sBoon(); vib(15);
+  renderShop();
+}
+function pickPack(o, choice){
+  if(!o.pack || o.pack.picked) return;
+  o.pack.picked=true;
+  grantItem(choice);                       // free — the $28 pack was already paid
+  sBoon(); vib(20);
+  renderShop();
+}
+function rarityWord(o){ return o.rarity==="pack" ? "Arcane" : (RARITY[o.rarity]||RARITY.common).word; }
+function rarityCls(o){ return o.rarity==="pack" ? "rar-pack" : "rar-"+(o.rarity||"common"); }
+function offerCardHTML(o){
+  var icon = o.type==="exotic" ? "✦" : o.type==="ritual" ? "◈" : REAGENT_BY_KEY[o.key].ic;
+  var dotsHtml = (o.type==="exotic"||o.type==="ritual")
+    ? o.recipe.map(function(c){ return '<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:'+HEX[c]+';border:1.5px solid #2c2733;vertical-align:middle;margin-right:2px;"></span>'; }).join('')
+    : "Reagent · passive";
+  var tagHtml = o.type==="ritual"
+    ? dotsHtml+'<span style="display:inline-block;margin-left:4px;font-size:8px;font-weight:800;letter-spacing:.4px;text-transform:uppercase;color:#8a5a12;background:#ffe6a8;padding:1px 5px;border-radius:7px;border:1.5px solid #2c2733;vertical-align:middle;">Ritual · any order</span>'
+    : dotsHtml;
+  var recBadge = o.recommended ? '<span class="rec-badge">★ recommended</span>' : '';
+  var mergeBadge = o.merge ? '<span class="merge-badge">◆ MERGE → II</span>' : '';
+  var mid = o.type==="reagent"?o.key:o.name;
+  var descTxt = o.merge ? (II_DESC[mid]||o.desc) : o.desc;
+  return '<div class="ic" style="background:'+o.bg+'">'+icon+'</div>'+
+    '<div style="flex:1;min-width:0;"><b>'+o.name+'</b>'+recBadge+mergeBadge+
+    '<span class="tag" style="text-transform:none;letter-spacing:0;">'+tagHtml+'</span>'+
+    '<span>'+descTxt+'</span></div>'+
+    '<div class="pricewrap"><div class="price"><i></i>'+o.price+'</div><span class="rarity">'+rarityWord(o)+'</span></div>'+
+    '<div class="sold-stamp">'+(o.merge?"MERGED":"SOLD")+'</div>';
+}
+function renderPackCard(box, o){
+  if(o.sold && o.pack && !o.pack.picked){                 // OPENED → the pick-1-of-3 reveal
+    var wrap=document.createElement("div"); wrap.className="packreveal";
+    var hd=document.createElement("div"); hd.className="pack-hd"; hd.textContent="Arcane Pack — choose one"; wrap.appendChild(hd);
+    var row=document.createElement("div"); row.className="cards";
+    o.pack.choices.forEach(function(ch){
+      var icon=ch.type==="exotic"?"✦":ch.type==="ritual"?"◈":REAGENT_BY_KEY[ch.key].ic;
+      var el=document.createElement("div"); el.className="rcard offer "+rarityCls(ch)+" packchoice";
+      el.innerHTML='<div class="ic" style="background:'+ch.bg+'">'+icon+'</div>'+
+        '<div style="flex:1;min-width:0;"><b>'+ch.name+'</b><span>'+ch.desc+'</span></div>'+
+        '<span class="rarity">'+rarityWord(ch)+'</span>';
+      el.addEventListener("click", function(){ pickPack(o, ch); });
+      row.appendChild(el);
+    });
+    if(!o.pack.choices.length){ var none=document.createElement("div"); none.className="pack-hd"; none.textContent="(nothing left to draft)"; wrap.appendChild(none); }
+    wrap.appendChild(row); box.appendChild(wrap); return;
+  }
+  var afford=!o.sold && S.motes>=o.price;
+  var el=document.createElement("div");
+  el.className="rcard offer rar-pack"+(o.sold?" sold":(afford?"":" cant"));
+  el.innerHTML='<div class="ic" style="background:'+o.bg+'">✦?</div>'+
+    '<div style="flex:1;min-width:0;"><b>Arcane Pack</b><span>pick 1 of 3 · any class</span></div>'+
+    '<div class="pricewrap"><div class="price"><i></i>'+o.price+'</div><span class="rarity">Arcane</span></div>'+
+    '<div class="sold-stamp">OPENED</div>';
+  if(afford) el.addEventListener("click", function(){ buyOffer(o); });
+  box.appendChild(el);
 }
 function renderShop(){
   var box=document.getElementById("rwShop"); if(!box) return; box.innerHTML="";
   S.bazaarOffers.forEach(function(o){
+    if(o.type==="pack"){ renderPackCard(box, o); return; }
     var afford = !o.sold && S.motes>=o.price;
     var el=document.createElement("div");
-    el.className="rcard offer"+(o.sold?" sold":(afford?"":" cant"));
-    var icon = o.type==="exotic" ? "✦" : o.type==="ritual" ? "◈" : REAGENT_BY_KEY[o.key].ic;
-    var dotsHtml = (o.type==="exotic"||o.type==="ritual")
-      ? o.recipe.map(function(c){ return '<span style="display:inline-block;width:9px;height:9px;border-radius:50%;background:'+HEX[c]+';border:1.5px solid #2c2733;vertical-align:middle;margin-right:2px;"></span>'; }).join('')
-      : "Reagent · passive";
-    // rituals wear an "any order" tag next to their (unordered) recipe dots
-    var tagHtml = o.type==="ritual"
-      ? dotsHtml+'<span style="display:inline-block;margin-left:4px;font-size:8px;font-weight:800;letter-spacing:.4px;text-transform:uppercase;color:#8a5a12;background:#ffe6a8;padding:1px 5px;border-radius:7px;border:1.5px solid #2c2733;vertical-align:middle;">Ritual · any order</span>'
-      : dotsHtml;
-    var recBadge = o.recommended ? '<span class="rec-badge" style="display:inline-block;margin-left:5px;font-size:8px;font-weight:800;letter-spacing:.3px;text-transform:uppercase;color:#2c2733;background:#ffd15c;padding:1px 5px;border-radius:7px;border:1.5px solid #2c2733;vertical-align:middle;">★ recommended</span>' : '';
-    el.innerHTML='<div class="ic" style="background:'+o.bg+'">'+icon+'</div>'+
-      '<div style="flex:1;min-width:0;"><b>'+o.name+'</b>'+recBadge+
-      '<span class="tag" style="text-transform:none;letter-spacing:0;">'+tagHtml+'</span>'+
-      '<span>'+o.desc+'</span></div>'+
-      '<div class="price"><i></i>'+o.price+'</div>'+
-      '<div class="sold-stamp">SOLD</div>';
+    el.className="rcard offer "+rarityCls(o)+(o.merge?" mergecard":"")+(o.sold?" sold":(afford?"":" cant"));
+    el.innerHTML=offerCardHTML(o);
     if(afford) el.addEventListener("click", function(){ buyOffer(o); });
     box.appendChild(el);
   });
+  renderRetire();
+}
+/* ---------- RETIRE SLOT (Peglin curation): remove an owned arcanum for an escalating fee ---------- */
+function retireFee(){ return 10*((S.retireN||0)+1); }                 // 10, 20, 30... per use this run
+function ownedArcanaList(){
+  var list=[];
+  S.exotics.forEach(function(n){ list.push({ cls:"exotic", id:n, name:n, bg:(EXOTIC_BY_NAME[n]||{}).bg||"#8a8390", ic:"✦" }); });
+  S.rituals.forEach(function(n){ list.push({ cls:"ritual", id:n, name:n, bg:(RITUAL_BY_NAME[n]||{}).bg||"#8a8390", ic:"◈" }); });
+  REAGENT.forEach(function(r){ if(S.reagents[r.key]) list.push({ cls:"reagent", id:r.key, name:r.name, bg:r.bg, ic:r.ic }); });
+  return list;
+}
+function renderRetire(){
+  var box=document.getElementById("rwRetire"); if(!box) return; box.innerHTML="";
+  var owned=ownedArcanaList();
+  if(!S.retireMode){
+    var row=document.createElement("div");
+    row.className="retire-row"+(owned.length?"":" cant");
+    row.innerHTML='<span class="retire-lbl">Retire an arcanum</span><span class="retire-fee"><i></i>'+retireFee()+'</span>';
+    if(owned.length) row.addEventListener("click", function(){ S.retireMode=true; S.retireSel=null; renderRetire(); });
+    box.appendChild(row);
+    return;
+  }
+  var hd=document.createElement("div"); hd.className="retire-hd";
+  hd.textContent="Retire which? Frees a slot · costs "+retireFee()+" motes"; box.appendChild(hd);
+  var grid=document.createElement("div"); grid.className="retire-grid";
+  owned.forEach(function(it){
+    var c=document.createElement("div"); c.className="retire-card"+(S.retireSel===it.id?" sel":"");
+    c.innerHTML='<div class="ic" style="background:'+it.bg+'">'+it.ic+'</div><b>'+it.name+'</b>'+(isII(it.id)?'<span class="ii">II</span>':'');
+    c.addEventListener("click", function(){ S.retireSel=(S.retireSel===it.id?null:it.id); renderRetire(); });
+    grid.appendChild(c);
+  });
+  box.appendChild(grid);
+  var actions=document.createElement("div"); actions.className="retire-actions";
+  var canConfirm = !!S.retireSel && S.motes>=retireFee();
+  var conf=document.createElement("button"); conf.className="mk retire-confirm"+(canConfirm?"":" dim");
+  conf.textContent = S.retireSel ? "Retire ("+retireFee()+")" : "Pick one";
+  conf.addEventListener("click", function(){ if(canConfirm) doRetire(); });
+  var back=document.createElement("button"); back.className="mk retire-cancel"; back.textContent="Back";
+  back.addEventListener("click", function(){ S.retireMode=false; S.retireSel=null; renderRetire(); });
+  actions.appendChild(conf); actions.appendChild(back);
+  box.appendChild(actions);
+}
+function doRetire(){
+  var id=S.retireSel; if(!id || S.motes<retireFee()) return;
+  S.motes-=retireFee(); moteHudSet();
+  S.retireN=(S.retireN||0)+1;
+  var i=S.exotics.indexOf(id); if(i>=0) S.exotics.splice(i,1);
+  var j=S.rituals.indexOf(id); if(j>=0) S.rituals.splice(j,1);
+  if(S.reagents[id]) delete S.reagents[id];
+  if(S.tier2) delete S.tier2[id];
+  S.retireMode=false; S.retireSel=null; S.dialSig="";
+  sBoon(); vib(20);
+  renderReagentBar(); renderShop();
 }
 /* the post-wave stall: free boon on top (pick one — then Continue), priced offers below */
 /* ---------- the free PRE-WAVE READOUT: pre-roll next wave & draw its scouting report ---------- */
@@ -1737,7 +2067,7 @@ function showReward(){
   renderNextWave(S.nextWaveSpec);
   if(S.nextWaveSpec.elite) setTimeout(function(){ if(S && !S.over) sEliteHorn(); }, 620);   // deeper horn sting, once, when the stall opens
   rollBazaar();
-  S.boonPicked=false;
+  S.boonPicked=false; S.retireMode=false; S.retireSel=null;   // retire UI resets each visit (fee count persists the run)
   var pool=ALL_UP.filter(function(u){
     if((S.boonN[u.k]||0)>=u.max) return false;
     if(u.k==="mend" && S.hp>=S.maxhp) return false;
@@ -1775,6 +2105,7 @@ function gameOver(){
   var st=S.stats||{}, rows=[];
   function row(k, v, hero){ rows.push('<div class="srow'+(hero?" hero":"")+'"><span class="sk">'+k+'</span><span class="sv">'+v+'</span></div>'); }
   row("Held for", st.waves+" wave"+(st.waves===1?"":"s"));   // always shown — the run's length
+  if(difficulty!=="standard") row("Difficulty", DIFF_LABEL[difficulty]||difficulty);   // only surfaced off-Standard
   if(st.bestCast) row("Best cast", "L"+st.bestCast.tl+" "+st.bestCast.name.toUpperCase()+" — "+st.bestCast.dmg, true);
   if(st.doublecasts) row("Doublecasts", st.doublecasts);
   if(st.creations) row("Creations", st.creations);
@@ -2112,7 +2443,8 @@ function drawExoticStrip(t){
     var artW = it.cls==="ritual"
       ? Math.ceil(it.recipe.length/2)*(chipR*2-1)+2 + 9        // cluster footprint + swirl
       : it.recipe.length*(chipR*2)+(it.recipe.length-1)*chipGap;
-    return { it:it, w:pad+artW+5+nameW+pad };
+    var iiW = isII(it.name) ? 14 : 0;                          // room for the II pip
+    return { it:it, w:pad+artW+5+nameW+iiW+pad, nameW:nameW, iiW:iiW };
   });
   var gap=8, tot=boxes.reduce(function(s,b){ return s+b.w; },0)+(boxes.length-1)*gap;
   var x=g.cx-tot/2;
@@ -2147,6 +2479,13 @@ function drawExoticStrip(t){
     }
     ctx.textAlign="left"; ctx.font="700 "+nameFont+"px Nunito, sans-serif"; ctx.fillStyle=spent?"#8a8578":"#2c2733";
     ctx.fillText(it.name, cxp+3, y+0.5);
+    if(isII(it.name)){                                          // MERGE→II pip: a small amber "II" badge after the name
+      var ibx=cxp+3+bx.nameW+3, iby=y;
+      ctx.fillStyle="#f0a92c"; rr(ibx, iby-6, 12, 12, 3); ctx.fill();
+      ctx.lineWidth=1.4; ctx.strokeStyle="#2c2733"; ctx.stroke();
+      ctx.fillStyle="#2c2733"; ctx.textAlign="center"; ctx.font="700 8px Fredoka, sans-serif";
+      ctx.fillText("II", ibx+6, iby+0.5); ctx.textAlign="left"; ctx.font="700 "+nameFont+"px Nunito, sans-serif";
+    }
     if(spent) ctx.globalAlpha = 1;
     x += bx.w+gap;
   });
@@ -3003,6 +3342,22 @@ document.getElementById("btnPause").addEventListener("click", function(){
   var m="turns"; try{ m=localStorage.getItem("wh_mode")||"turns"; }catch(e){}
   document.getElementById(m==="flow"?"btnFlow":"btnStart").classList.add("accent");
 })();
+/* difficulty toggle: three chips, last choice pre-lit + persisted to wh_diff */
+function litDiff(){
+  var btns=document.querySelectorAll("#diffRow .diffbtn");
+  for(var i=0;i<btns.length;i++) btns[i].classList.toggle("accent", btns[i].getAttribute("data-diff")===difficulty);
+}
+(function(){
+  var btns=document.querySelectorAll("#diffRow .diffbtn");
+  for(var i=0;i<btns.length;i++){ (function(b){
+    b.addEventListener("click", function(){
+      var d=b.getAttribute("data-diff"); if(!DIFF[d]) return;
+      difficulty=d; try{ localStorage.setItem("wh_diff", d); }catch(e){}
+      litDiff(); beep(520,.06,"sine",.04);
+    });
+  })(btns[i]); }
+  litDiff();
+})();
 document.getElementById("btnEnd").addEventListener("click", function(){
   if(!S||S.busy||S.over||CFG.realtime) return;
   S.busy=true; syncHud(); setTimeout(triggerPhase, 120);
@@ -3026,6 +3381,8 @@ window.__wh = function(){
     foes: S.enemies.map(function(e){ return { lane:e.lane, rung:e.rung, ward:e.ward, brute:e.brute, elite:e.elite, armored:e.armored, healer:e.healer, leech:e.leech, hp:e.hp, dmg:e.dmg }; }),
     paused: S.paused, busy: S.busy, phase: S.phase, over: S.over, wave: S.wave, hp: S.hp,
     motes: S.motes, exotics: S.exotics.slice(), rituals: S.rituals.slice(), reagents: Object.keys(S.reagents),
+    difficulty: difficulty, tier2: Object.keys(S.tier2||{}), retireN: S.retireN,
+    bazaarOffers: S.bazaarOffers.map(function(o){ return { type:o.type, name:o.name, key:o.key, price:o.price, rarity:o.rarity, merge:!!o.merge, sold:!!o.sold }; }),
     creations: S.creations.filter(function(c){ return !c.dead; }).map(function(c){ return { kind:c.kind, lane:c.lane, rung:c.rung, hp:c.hp, maxhp:c.maxhp, attack:c.attack, tl:c.tl }; }),
     pyre: S.pyre ? { lane:S.pyre.lane, rung:S.pyre.rung } : null,
     pendingDouble: S.pendingDouble, gildNext: S.gildNext,

--- a/whorl/index.html
+++ b/whorl/index.html
@@ -184,6 +184,52 @@ body{
 .rcard.chosen{ background:var(--accent); }
 .rcard.chosen:active{ transform:none; box-shadow:0 3px 0 var(--shadow); }
 .cards.locked .rcard:not(.chosen){ opacity:.42; pointer-events:none; }
+
+/* ---------- NEXT WAVE readout (free intel — the Bazaar's scouting report) ---------- */
+.nextwave{ margin:2px 0 4px; padding:9px 10px 8px; background:var(--paper2);
+  border:2.5px solid var(--ink); border-radius:15px; box-shadow:0 3px 0 var(--shadow); }
+.nextwave:empty{ display:none; }
+.nw-label{ font-family:var(--font-d); font-weight:700; font-size:11px; letter-spacing:.11em;
+  text-transform:uppercase; color:var(--ink-soft); text-align:left; margin:0 0 7px 1px; }
+.nw-ribbon{ display:block; font-family:var(--font-d); font-weight:700; font-size:13.5px; letter-spacing:.05em;
+  color:#fffdf6; background:#ef4a5a; border:2.5px solid var(--ink); border-radius:10px 10px 10px 2px;
+  box-shadow:0 2px 0 var(--shadow); padding:4px 8px; margin:0 0 9px; text-align:center; transform:rotate(-.9deg); }
+.nw-lanes{ display:flex; gap:6px; align-items:flex-start; }
+.nw-lane{ flex:1; display:flex; flex-direction:column; align-items:center; gap:5px; min-height:22px; }
+.nw-lane .nw-ln{ font-family:var(--font-u); font-weight:800; font-size:8.5px; letter-spacing:.06em; color:rgba(44,39,51,.4); }
+.nw-lane.hot .nw-ln{ color:var(--ink); }
+.nw-chips{ display:flex; flex-direction:column; gap:5px; align-items:center; padding-top:1px; }
+.nw-empty{ width:9px; height:2px; border-radius:1px; background:rgba(44,39,51,.16); margin-top:5px; }
+.nw-sum{ text-align:left; font-weight:700; font-size:11px; color:var(--ink-soft); margin:9px 1px 0; line-height:1.45; }
+.nw-sum b{ color:var(--ink); }
+/* the drawn chips — one per incoming foe, in house shapes/colours */
+.nw-chip{ position:relative; width:18px; height:18px; box-sizing:border-box;
+  border:2px solid var(--ink); background:#cfc5b2; flex:none; }
+.nw-chip.normal{ border-radius:50%; }
+.nw-chip.brute{ border-radius:5px; background:#b7ad9a; }
+.nw-chip.armored{ border-radius:50%; }
+.nw-chip.armored::after{ content:""; position:absolute; left:1px; right:1px; top:5.5px; height:4px; background:#4a4454; }
+.nw-chip.healer{ border-radius:50%; }
+.nw-chip.healer::before{ content:""; position:absolute; left:50%; top:3.5px; width:2.5px; height:9px; background:#fffdf6; transform:translateX(-50%); }
+.nw-chip.healer::after{ content:""; position:absolute; left:4px; right:4px; top:7.5px; height:2.5px; background:#fffdf6; }
+.nw-chip.leech{ border-radius:50%; }
+.nw-chip.leech::after{ content:""; position:absolute; left:50%; bottom:2.5px; transform:translateX(-50%);
+  width:0; height:0; border-left:3px solid transparent; border-right:3px solid transparent; border-top:5px solid var(--ink); }
+.nw-chip.elite{ width:23px; height:23px; border-radius:5px; border-width:2.5px; background:#8f8677; }
+.nw-chip.elite::after{ content:""; position:absolute; left:2.5px; top:2.5px; right:2.5px; bottom:2.5px; border:1.5px solid rgba(255,209,92,.55); border-radius:3px; }
+.nw-crown{ position:absolute; left:50%; top:-8px; transform:translateX(-50%); width:16px; height:8px; background:var(--accent);
+  clip-path:polygon(0 100%,0 42%,25% 72%,50% 12%,75% 72%,100% 42%,100% 100%); filter:drop-shadow(0 1.2px 0 rgba(44,39,51,.9)); }
+.nw-chip.warded{ box-shadow:0 0 0 1.5px var(--card), 0 0 0 3.5px var(--wardc,#f2913d); }
+
+/* ---------- death-screen run stats: failure reads as progress ---------- */
+.statcard{ text-align:left; margin:6px 0 2px; padding:11px 15px; background:var(--paper2);
+  border:2.5px solid var(--ink); border-radius:15px; box-shadow:0 3px 0 var(--shadow); }
+.statcard .srow{ display:flex; justify-content:space-between; align-items:baseline; gap:10px;
+  font-weight:700; font-size:13px; padding:4px 0; border-bottom:1.5px dashed rgba(44,39,51,.14); }
+.statcard .srow:last-child{ border-bottom:0; }
+.statcard .srow .sk{ color:var(--ink-soft); }
+.statcard .srow .sv{ font-family:var(--font-d); font-weight:700; color:var(--ink); font-size:14px; white-space:nowrap; }
+.statcard .srow.hero .sv{ color:#b9791a; }
 </style>
 </head>
 <body>
@@ -233,6 +279,7 @@ body{
   <div class="panel bazaarpanel">
     <h2 id="rwTitle">The Bazaar</h2>
     <p id="rwSub" style="margin:2px 0 4px;">The stalls open between the fighting. Take a boon — then spend, if you like.</p>
+    <div class="nextwave" id="rwNext"></div>
     <div class="bazaarscroll">
       <div class="shopsec">
         <div class="seclabel">Take one</div>
@@ -261,8 +308,9 @@ body{
 <div class="veil" id="vOver">
   <div class="panel">
     <h2 id="ovTitle">The wall breaks</h2>
-    <p id="ovMsg"></p>
-    <div class="row"><button class="mk accent" id="btnRetry" style="flex:1;height:50px;font-size:17px;">Try again</button></div>
+    <p id="ovMsg" style="margin:8px 0 6px;"></p>
+    <div class="statcard" id="ovStats"></div>
+    <div class="row"><button class="mk accent" id="btnRetry" style="flex:1;height:50px;font-size:17px;">Run it back</button></div>
     <div class="credit"><a href="/" title="İzge Bayyurt">İzge Bayyurt ↗</a></div>
   </div>
 </div>
@@ -289,6 +337,7 @@ var CFG = {
 /* colours ---------------------------------------------------------------- */
 var HEX = { R:"#ef4a5a", Y:"#f6c445", B:"#3d8bdf", O:"#f2913d", G:"#57c268", P:"#9b62d6", H:"#b9b2a6", W:"#f4f0ff" };
 var NAME = { R:"Red", Y:"Yellow", B:"Blue", O:"Orange", G:"Green", P:"Purple", H:"Husk", W:"Prism" };
+var WARDNAME = { O:"orange", G:"green", P:"purple" };   // ward colours, lower-case for the readout summary
 var PRIM = { R:1, Y:1, B:1 };
 function isPrim(c){ return !!PRIM[c]; }
 function mix(a,b){
@@ -369,8 +418,13 @@ function newGame(){
     dialSig:"", exoticGlow:{}, masonFlash:0,        // strip-glow cache + Mason gate flourish
     // ---- FLOW MODE clocks (delta-accumulated; only advance while unpaused) ----
     cool:0, coolMax:CFG.castCd, coolPulse:0,        // cast cooldown
+    chain:0, readyElapsed:0,                        // FLOW CHAINING: consecutive prompt-cast count + idle-since-ready timer
     beatT:0, beatMax:4.0,                           // metronome for the horde
-    paused:false, phaseRunning:false, phaseQueued:false
+    paused:false, phaseRunning:false, phaseQueued:false,
+    // ---- PRE-WAVE READOUT: the next wave's spec, pre-rolled at wave clear (preview === spawn) ----
+    nextWaveSpec:null,
+    // ---- run stats (for the death-screen readout; only nonzero rows show) ----
+    stats:{ waves:0, bestCast:null, doublecasts:0, creations:0, motes:0, prisms:0 }
   };
   for(var i=0;i<CFG.slots;i++) S.dial.push(freshBall());
   renderReagentBar();
@@ -390,15 +444,10 @@ function alive(){ return S.enemies.filter(function(e){ return !e.dead; }); }
    type mix: brutes as before; of the rest ~20% armored (wave 3+), ~20% leech (wave 4+,
    max 2), one healer per wave at ~35% (wave 4+, mid-field rung 2-3 & SKITTISH). every 5th
    wave trades two normal spawns for one ELITE. */
-function nextWave(){
-  var st=S;
-  st.wave++;
-  st.enemies = [];
-  st.lastSpell=null; st.repeatN=0;        // a new wave forgives old habits
-  st.aurumSpent=false;                    // Aurum: rechargeable once per wave
-  st.pyre=null;                           // Pyre Ground is wave-scoped (creations persist — they're monuments)
-  st.firstTransmuteUsed=false;            // Catalyst: first free transmute resets each wave/turn
-  var w=st.wave;
+/* rollWave(w) — the PURE spec generator. Given only a wave number it rolls the full spawn list
+   (types, lanes, rungs, wards, hp, dmg) as plain data. No side effects, no DOM, no now(): the SAME
+   spec drives both the Bazaar's NEXT-WAVE preview and the actual spawn, so they can never diverge. */
+function rollWave(w){
   var elite = (w>=8 && (w-8)%4===0);      // elite cadence: 8, 12, 16, 20...
   var count = Math.min(9, 2 + w) - (elite?2:0);
   var wardChance = Math.min(0.75, 0.05 + w*0.10);
@@ -408,6 +457,7 @@ function nextWave(){
   var total = count + (elite?1:0);
   var wantHealer = w>=4 && Math.random()<0.35;   // at most 1 healer per wave
   var leechN = 0;                                 // max 2 leeches per wave
+  var list = [];
   for(var k=0;k<total;k++){
     var isElite = elite && k===0;
     var isHealer = !isElite && wantHealer && k===total-1;
@@ -427,30 +477,58 @@ function nextWave(){
     var warded = !isElite && !brute && !armored && !leech && !isHealer && Math.random()<wardChance;
     var ward = (isElite||warded) ? ["O","G","P"][(Math.random()*3)|0] : null;
     var hp = isElite ? Math.round((16+8*w)*2.6) : brute ? (16+8*w) : (4+3*w);
-    st.enemies.push({
-      lane:lane, rung:rung, x:laneX(lane), y:rungY(rung),
-      hp:hp, maxhp:hp, ward:ward, brute:brute||isElite,
+    list.push({
+      lane:lane, rung:rung, hp:hp, maxhp:hp, ward:ward, brute:brute||isElite,
       elite:isElite, armored:armored, healer:isHealer, leech:leech,
       dmg: isHealer? 0 : isElite? baseDmg*3 : brute? baseDmg*2 : baseDmg,
-      freeze:0, frImm:0, poison:0, burn:0,
-      slow: (brute&&!isElite)?1:0, slowT:0,   // elites march every turn — sim showed slowed elites never reach the wall
-      seed: (lane*7+k*13)%97, jit: ((k*29)%9)-4,
+      slow: (brute&&!isElite)?1:0,             // elites march every turn — sim showed slowed elites never reach the wall
+      seed: (lane*7+k*13)%97, jit: ((k*29)%9)-4
+    });
+  }
+  return { wave:w, elite:elite, enemies:list };
+}
+/* spawnWave(spec) — the CONSUMER. Turns a spec (from the preview or a fresh roll) into live enemies
+   on the field with their timing/booms, and starts the turn/beat clocks. */
+function spawnWave(spec){
+  var st=S;
+  st.wave = spec.wave;
+  st.enemies = [];
+  st.lastSpell=null; st.repeatN=0;        // a new wave forgives old habits
+  st.aurumSpent=false;                    // Aurum: rechargeable once per wave
+  st.pyre=null;                           // Pyre Ground is wave-scoped (creations persist — they're monuments)
+  st.firstTransmuteUsed=false;            // Catalyst: first free transmute resets each wave/turn
+  spec.enemies.forEach(function(es,k){
+    st.enemies.push({
+      lane:es.lane, rung:es.rung, x:laneX(es.lane), y:rungY(es.rung),
+      hp:es.hp, maxhp:es.maxhp, ward:es.ward, brute:es.brute,
+      elite:es.elite, armored:es.armored, healer:es.healer, leech:es.leech,
+      dmg:es.dmg, freeze:0, frImm:0, poison:0, burn:0,
+      slow:es.slow, slowT:0, seed:es.seed, jit:es.jit,
       spawn: now()+k*80, hit:0, dotT:0, stepT:0, dead:false, deadAt:0
     });
     (function(e,delay){ setTimeout(function(){ if(S===st&&!st.over){
       boom(e.x,e.y,"#c9c1b4", e.elite?1.6:.45);                       // heavier boom for the elite
       beep(e.elite?150:300+e.lane*40, e.elite?.14:.06,"sine", e.elite?.06:.03);
     } }, delay); })(st.enemies[k], k*80);
-  }
+  });
   st.actions = st.maxActions = CFG.actions + CFG.maxActionsUp + (st.reagents.quicksilver?1:0);   // Quicksilver: +1/turn
   st.freeMerge = true;
   // FLOW: the beat tightens each wave — 4.0s at wave 1, -0.1s/wave, floor 2.5s
   st.beatMax = Math.max(2.5, 4.0 - (st.wave-1)*0.1);
   st.beatT = 0;
+  st.chain = 0; st.readyElapsed = 0;      // a fresh wave resets the flow chain
   sHorn();
   toast("Wave "+st.wave, 950, "#2c2733", "mid");
-  if(elite){ setTimeout(function(){ if(S===st&&!st.over){ toast("ELITE!", 1100, "#2c2733", "mid", true); sEliteHorn(); } }, 1000); }
+  if(spec.elite){ setTimeout(function(){ if(S===st&&!st.over){ toast("ELITE!", 1100, "#2c2733", "mid", true); sEliteHorn(); } }, 1000); }
   syncHud();
+}
+/* nextWave — consume the pre-rolled spec if it's the right wave (preview === spawn), else roll fresh */
+function nextWave(){
+  var st=S;
+  var target=st.wave+1;
+  var spec=(st.nextWaveSpec && st.nextWaveSpec.wave===target) ? st.nextWaveSpec : rollWave(target);
+  st.nextWaveSpec=null;
+  spawnWave(spec);
 }
 
 /* ===================== audio ===================== */
@@ -476,6 +554,7 @@ function sHorn(){ beep(220,.2,"triangle",.05); setTimeout(function(){beep(330,.2
 function sEliteHorn(){ beep(140,.3,"triangle",.06); setTimeout(function(){beep(105,.35,"triangle",.06);},180); setTimeout(function(){beep(210,.28,"triangle",.05);},340); }
 function sClank(){ beep(190,.05,"square",.05); setTimeout(function(){beep(120,.06,"square",.04);},45); }   // armored bounce
 function sChime(){ beep(660,.12,"sine",.035); setTimeout(function(){beep(880,.15,"sine",.03);},85); }      // healer pulse
+function sChainChime(lvl){ beep(720+lvl*150,.06,"sine",.03); }                                             // flow chain: pitch rises with the chain
 function sDrain(){ beep(240,.14,"sawtooth",.035); setTimeout(function(){beep(170,.16,"sawtooth",.03);},90); }
 function sWin(){ [0,110,220,420].forEach(function(t,i){ setTimeout(function(){ beep(440+i*140,.16,"triangle",.05); },t); }); }
 function vib(p){ if(navigator.vibrate){ try{ navigator.vibrate(p); }catch(e){} } }
@@ -520,6 +599,7 @@ function recordSpell(sp, isDouble){
   if(!BOOK[name]){ BOOK[name]={ n:0, dc:0 }; if(LEGEND[name]) inscribe(name); }
   BOOK[name].n++;
   if(isDouble) BOOK[name].dc++;
+  if(name==="Prism" && S && S.stats) S.stats.prisms++;   // every Prism mint routes through here — death readout
   saveBook();
 }
 function inscribe(name){
@@ -651,7 +731,7 @@ function applyDmg(e, amt, el, opts){
     if(e.armored && amt<5){
       e.hit = now(); sClank();
       spawnDmg(e.x, e.y-geo.ballR*0.9, 0, false, false, false, opts.friend);
-      return;
+      return 0;                                    // plate bounced — no damage dealt
     }
   }
   if(e.freeze>0 && S.reagents && S.reagents.shatterfrost) amt = Math.round(amt*1.5);   // Shatterfrost: +50% on the frozen
@@ -678,6 +758,7 @@ function applyDmg(e, amt, el, opts){
     boom(e.x, e.y, "#c9c1b4", .5);   // dust boom as it scrambles back
     beep(700, .09, "sine", .045);    // squeak
   }
+  return amt;                        // damage actually dealt (post-ward/frost) — fed to the best-cast tally
 }
 /* Void's "assassin" seeks the toughest foe alive (highest maxhp) — ignores tgt */
 function targetsFor(sp, tgt){
@@ -729,6 +810,7 @@ function moteChipXY(){
 function addMotes(amt, x, y){
   if(!amt || amt<=0) return;
   S.motes += amt;
+  if(S.stats) S.stats.motes += amt;      // gross motes earned this run — death readout (not reduced by spending)
   moteHudSet();
   var tgt=moteChipXY(), dots=Math.min(3, Math.max(1, amt));
   for(var i=0;i<dots;i++){
@@ -747,13 +829,22 @@ function moteLand(){
 function impactSpell(sp, hits){
   var per = (sp.kind==="all" && hits.length) ? Math.ceil(sp.dmg/hits.length) : sp.dmg;   // AoE splits damage
   var opts = { trueDamage:sp.trueDamage, eclipsePierce:sp.eclipsePierce, usedW:sp.usedW };
+  var dealt=0;
   hits.forEach(function(e){
-    applyDmg(e, per, sp.el, opts);
+    dealt += applyDmg(e, per, sp.el, opts) || 0;
     if(sp.freeze && !e.frImm) e.freeze = Math.max(e.freeze, sp.freeze);
     if(sp.poison) e.poison = Math.min(POISON_CAP, e.poison + sp.poison);   // poison stacks cap at 12
     if(sp.burn) applyBurn(e, sp.burn);
   });
+  recordCast(sp, dealt);   // best-cast tracking — each doublecast half lands here separately
   S.shake = Math.min(20, 4 + sp.tl*1.1 + (sp.tl>=6?4:0) + (sp.whorl?6:0));
+}
+/* best-cast bookkeeping: the single hardest-hitting spell landing this run (by total damage dealt).
+   doublecast halves and Mordant repeats each arrive as their own impactSpell, so each counts alone. */
+function recordCast(sp, dealt){
+  if(!S.stats || !sp || sp.fizzle || dealt<=0) return;
+  var b=S.stats.bestCast;
+  if(!b || dealt>b.dmg) S.stats.bestCast = { name:sp.name, dmg:dealt, tl:sp.tl||1 };
 }
 /* anticipation -> impact: balls flash+shrink (150ms) -> beam -> damage (230ms) -> refill (300ms) */
 function cast(idxs){
@@ -856,6 +947,7 @@ function castWeave(idxs){
   var spA=null, spB=null;
   if(idxs.length===6){ spA=resolveSpell(balls.slice(0,3)); spB=resolveSpell(balls.slice(3,6)); }
   if(!spA || spA.fizzle || spB.fizzle){ weaveCollapse(idxs, balls); return; }
+  if(S.stats) S.stats.doublecasts++;                        // a real weave landed — tally it for the death readout
   /* a transmute link is a valid (non-fizzle) weave step: it mints a Prism instead of striking.
      a pure-transmute weave is a craft (no cooldown); any real spell arms the cast cooldown. */
   var anyReal = !spA.transmute || !spB.transmute;
@@ -1179,6 +1271,7 @@ function summonCreation(st, kind, TL){
   var c={ kind:kind, lane:lane, rung:rung, hp:stt.hp, maxhp:stt.hp, attack:stt.attack, tl:TL,
     x:laneX(lane), y:rungY(rung), born:now(), hit:0, sq:0, act:0, dead:false, deadAt:0 };
   st.creations.push(c);
+  if(st.stats) st.stats.creations++;                                     // monument raised — death readout
   boom(c.x, c.y, creationTint(kind), CREATION_LOOK[kind].big?2.0:1.6);   // pop-in + summon boom
   confetti(c.x, c.y, creationTint(kind));
   S.fx.push({ star:true, x:c.x, y:c.y, t:now(), tint:creationTint(kind) });
@@ -1321,7 +1414,22 @@ function postAction(){
 /* FLOW: casting on cooldown — soft reject, no penalty, no balls consumed.
    Quicksilver shaves 12% off the cast cooldown. */
 function effCastCd(){ return CFG.castCd * (S && S.reagents.quicksilver ? 0.88 : 1); }
-function startCool(){ S.cool = effCastCd(); S.coolMax = S.cool; }
+/* FLOW CHAINING: casting within CHAIN_WINDOW of the spiral becoming ready shaves the NEXT cooldown
+   CHAIN_STEP per consecutive prompt cast (stacking to CHAIN_MAX), floored at CHAIN_FLOOR seconds.
+   Multiplicative with Haste + Quicksilver (both baked into effCastCd). Idling resets the chain. */
+var CHAIN_WINDOW=2.0, CHAIN_STEP=0.88, CHAIN_MAX=2, CHAIN_FLOOR=1.0;
+function startCool(){
+  if(CFG.realtime){
+    var prompt = S.readyElapsed <= CHAIN_WINDOW;                // cast fired promptly after ready?
+    S.chain = prompt ? Math.min(CHAIN_MAX, S.chain+1) : 0;      // extend the chain, or reset on a lazy cast
+    if(prompt && S.chain>=2) sChainChime(S.chain);              // pitch-up chime once the chain actually stacks
+  }
+  var f = CFG.realtime ? Math.pow(CHAIN_STEP, S.chain) : 1;     // 0.88^chain
+  S.cool = effCastCd()*f;
+  if(CFG.realtime) S.cool = Math.max(CHAIN_FLOOR, S.cool);      // never below 1.0s absolute
+  S.coolMax = S.cool;
+  S.readyElapsed = 0;
+}
 function coolReject(){ sThunk(); toast("cooling...", 700, "#6b6472", "low"); vib(6); }
 /* Mordant's charge, still live? (Flow lets it lapse after 6s) */
 function doublePending(){
@@ -1447,6 +1555,8 @@ function endEnemyPhase(){
 function waveClear(){
   if(S.over||S.phase==="clear") return;
   S.busy=true; S.phase="clear";
+  if(S.stats) S.stats.waves++;                 // held one more wave — death readout
+
   if(S.reagents.mason){ S.hp=Math.min(S.maxhp, S.hp+1); S.masonFlash=now(); syncHud(); }   // Mason re-lays a block
   sWin(); vib(20);
   toast("WAVE CLEAR!", 850, "#2c2733", "mid", true);
@@ -1576,7 +1686,56 @@ function renderShop(){
   });
 }
 /* the post-wave stall: free boon on top (pick one — then Continue), priced offers below */
+/* ---------- the free PRE-WAVE READOUT: pre-roll next wave & draw its scouting report ---------- */
+function renderNextWave(spec){
+  var box=document.getElementById("rwNext"); if(!box) return;
+  box.innerHTML="";
+  if(!spec){ return; }
+  var es=spec.enemies;
+  // ELITE ribbon across the top of the section
+  if(spec.elite){ var rib=document.createElement("div"); rib.className="nw-ribbon"; rib.textContent="⚑ ELITE APPROACHES"; box.appendChild(rib); }
+  var lbl=document.createElement("div"); lbl.className="nw-label"; lbl.textContent="Next wave"; box.appendChild(lbl);
+  // per-lane mini-columns, front foes (lowest rung) on top
+  var lanes=document.createElement("div"); lanes.className="nw-lanes";
+  for(var l=0;l<CFG.lanes;l++){
+    var col=document.createElement("div"); col.className="nw-lane";
+    var foes=es.filter(function(e){ return e.lane===l; }).sort(function(a,b){ return a.rung-b.rung; });
+    if(foes.length) col.classList.add("hot");
+    var ln=document.createElement("div"); ln.className="nw-ln"; ln.textContent=(l+1); col.appendChild(ln);
+    var chips=document.createElement("div"); chips.className="nw-chips";
+    if(!foes.length){ var em=document.createElement("div"); em.className="nw-empty"; chips.appendChild(em); }
+    foes.forEach(function(e){ chips.appendChild(makeFoeChip(e)); });
+    col.appendChild(chips); lanes.appendChild(col);
+  }
+  box.appendChild(lanes);
+  // terse summary line
+  var sum=document.createElement("div"); sum.className="nw-sum"; sum.innerHTML=waveSummary(spec); box.appendChild(sum);
+}
+/* one drawn CSS chip per foe, shape+colour per archetype, ward as a coloured ring */
+function makeFoeChip(e){
+  var chip=document.createElement("div"); chip.className="nw-chip ";
+  chip.className += e.elite?"elite" : e.brute?"brute" : e.armored?"armored" : e.healer?"healer" : e.leech?"leech" : "normal";
+  if(e.elite){ var cr=document.createElement("div"); cr.className="nw-crown"; chip.appendChild(cr); }
+  if(e.ward){ chip.classList.add("warded"); chip.style.setProperty("--wardc", HEX[e.ward]); }
+  return chip;
+}
+/* the count line: "5 foes · 1 armored · lane 3 warded orange" — terse, only what's notable */
+function waveSummary(spec){
+  var es=spec.enemies, n=es.length, parts=[];
+  parts.push("<b>"+n+"</b> foe"+(n===1?"":"s"));
+  if(spec.elite) parts.push("<b>1 elite</b>");
+  var cnt={ brute:0, armored:0, healer:0, leech:0 };
+  es.forEach(function(e){ if(e.elite) return; if(e.brute) cnt.brute++; else if(e.armored) cnt.armored++; else if(e.healer) cnt.healer++; else if(e.leech) cnt.leech++; });
+  ["brute","armored","healer","leech"].forEach(function(k){ if(cnt[k]) parts.push(cnt[k]+" "+k); });
+  var warded=es.filter(function(e){ return e.ward && !e.elite; });
+  if(warded.length===1) parts.push("lane "+(warded[0].lane+1)+" warded "+WARDNAME[warded[0].ward]);
+  else if(warded.length>1) parts.push(warded.length+" warded ("+warded.map(function(e){ return "L"+(e.lane+1)+" "+WARDNAME[e.ward]; }).join(", ")+")");
+  return parts.join(" · ");
+}
 function showReward(){
+  S.nextWaveSpec = rollWave(S.wave+1);      // pre-roll the NEXT wave now — preview and spawn share this exact spec
+  renderNextWave(S.nextWaveSpec);
+  if(S.nextWaveSpec.elite) setTimeout(function(){ if(S && !S.over) sEliteHorn(); }, 620);   // deeper horn sting, once, when the stall opens
   rollBazaar();
   S.boonPicked=false;
   var pool=ALL_UP.filter(function(u){
@@ -1609,9 +1768,19 @@ function showReward(){
   document.getElementById("rwSub").textContent = "Wave "+S.wave+" cleared. Take a boon, then spend your motes.";
   show("vReward");
 }
+/* the death screen reads as a run report, not a funeral — a tight card of what you pulled off. */
 function gameOver(){
   S.over=true; S.busy=true;
-  document.getElementById("ovMsg").innerHTML = "You held for <b>"+S.wave+"</b> wave"+(S.wave===1?"":"s")+". The colour fades — for now.";
+  document.getElementById("ovMsg").textContent = "The colour fades — for now.";
+  var st=S.stats||{}, rows=[];
+  function row(k, v, hero){ rows.push('<div class="srow'+(hero?" hero":"")+'"><span class="sk">'+k+'</span><span class="sv">'+v+'</span></div>'); }
+  row("Held for", st.waves+" wave"+(st.waves===1?"":"s"));   // always shown — the run's length
+  if(st.bestCast) row("Best cast", "L"+st.bestCast.tl+" "+st.bestCast.name.toUpperCase()+" — "+st.bestCast.dmg, true);
+  if(st.doublecasts) row("Doublecasts", st.doublecasts);
+  if(st.creations) row("Creations", st.creations);
+  if(st.prisms) row("Prisms minted", st.prisms);
+  if(st.motes) row("Motes earned", st.motes);
+  document.getElementById("ovStats").innerHTML = rows.join("");
   show("vOver");
 }
 
@@ -1725,7 +1894,8 @@ function flowPaused(){
 }
 function updateFlow(dt){
   if(flowPaused()) return;
-  if(S.cool>0){ S.cool-=dt; if(S.cool<=0){ S.cool=0; S.coolPulse=now(); beep(880,.07,"sine",.04); } }
+  if(S.cool>0){ S.cool-=dt; if(S.cool<=0){ S.cool=0; S.coolPulse=now(); S.readyElapsed=0; beep(880,.07,"sine",.04); } }
+  else { S.readyElapsed += dt; if(S.chain>0 && S.readyElapsed>CHAIN_WINDOW) S.chain=0; }   // idle past the window drops the chain (delta-accumulated → pause-safe)
   if(S.phase!=="clear"){                     // the horde holds its breath during a wave clear / draft
     S.beatT+=dt;
     if(S.beatT>=S.beatMax){ S.beatT-=S.beatMax; triggerPhase(); }
@@ -2127,6 +2297,28 @@ function drawEnemies(t){
       ctx.fillStyle = e.hp/e.maxhp>0.4? "#57c268" : "#ef4a5a";
       rr(bx+1.5,by+1.5,(bw-3)*Math.max(0,e.hp/e.maxhp),bh-3,2); ctx.fill();
     }
+    // THREAT GARNISH — armored: a small ink "plate" badge showing the bounce threshold (hits under 5 do 0)
+    if(e.armored && !e.dead){
+      var pbx=e.x - r*0.9 - 12, pby=by+3.5;
+      ctx.save(); ctx.translate(pbx,pby); ctx.textAlign="center"; ctx.textBaseline="middle";
+      ctx.fillStyle="rgba(44,39,51,.9)"; rr(-8,-4,16,13,4); ctx.fill();          // sticker shadow
+      ctx.fillStyle="#4a4454"; ctx.strokeStyle="#2c2733"; ctx.lineWidth=2; rr(-8,-6,16,13,4); ctx.fill(); ctx.stroke();
+      ctx.strokeStyle="rgba(255,255,255,.28)"; ctx.lineWidth=1.4; ctx.beginPath(); ctx.moveTo(-5,-2.5); ctx.lineTo(5,-2.5); ctx.stroke();
+      ctx.fillStyle="#fffdf6"; ctx.font="700 10px Fredoka, sans-serif"; ctx.fillText("5", 0, 1);
+      ctx.textBaseline="alphabetic"; ctx.restore();
+    }
+    // THREAT GARNISH — elite: a small gold crown badge above the bar
+    if(e.elite && !e.dead){
+      var crY=e.y+bob-pr-26;
+      ctx.save(); ctx.translate(e.x, crY);
+      function crown(off){ ctx.beginPath();
+        ctx.moveTo(-9,4+off); ctx.lineTo(-9,-2+off); ctx.lineTo(-4.5,2+off); ctx.lineTo(0,-5+off);
+        ctx.lineTo(4.5,2+off); ctx.lineTo(9,-2+off); ctx.lineTo(9,4+off); ctx.closePath(); }
+      crown(2); ctx.fillStyle="rgba(44,39,51,.9)"; ctx.fill();
+      crown(0); ctx.fillStyle="#ffd15c"; ctx.fill(); ctx.lineWidth=2; ctx.strokeStyle="#2c2733"; ctx.stroke();
+      ctx.fillStyle="#2c2733"; [-4.5,0,4.5].forEach(function(jx){ ctx.beginPath(); ctx.arc(jx,1.5,1.1,0,7); ctx.fill(); });
+      ctx.restore();
+    }
     // intent: drawn ink triangle (advance) or red damage badge (attacking the wall)
     if(e.freeze>0){ /* frozen: chip says it */ }
     else if(e.rung<=0 && e.dmg>0){
@@ -2440,19 +2632,23 @@ function drawHub(t){
     // FLOW: the whorl doubles as the cast-cooldown gauge — arc-length = readiness (empty right after a cast)
     var frac = S.coolMax>0 ? Math.max(0,Math.min(1, 1 - S.cool/S.coolMax)) : 1;
     var pulseK = S.coolPulse ? Math.max(0,1-(t-S.coolPulse)/500) : 0;
+    var chainK = S.chain||0;                         // 0..2 — the flow chain level tints the whorl
     ctx.save(); ctx.translate(g.cx, g.cy);           // caption gone — the spiral sits centred
     // faint full-spiral track so the empty state still reads as a whorl
     ctx.strokeStyle="rgba(44,39,51,.14)"; ctx.lineWidth=2.5; ctx.beginPath();
     for(var af=0;af<=Math.PI*5;af+=0.14){ var rf=2.5+af*2.1; if(af===0)ctx.moveTo(rf,0); else ctx.lineTo(Math.cos(af)*rf,Math.sin(af)*rf); }
     ctx.stroke();
-    // readiness portion, solid; gold flash on the ready pulse
-    ctx.strokeStyle= pulseK>0 ? "rgba("+Math.round(224-40*(1-pulseK))+",160,32,1)" : "#2c2733";
-    ctx.lineWidth=3.2+2*pulseK; ctx.beginPath();
+    // readiness portion, solid; gold flash on the ready pulse, gold-tinted at chain 2
+    var restCol = chainK>=2 ? "rgba(140,101,26,0.95)" : "#2c2733";   // faint gold tint at full chain
+    ctx.strokeStyle= pulseK>0 ? "rgba("+Math.round(224-40*(1-pulseK))+",160,32,1)" : restCol;
+    ctx.lineWidth=3.2+2*pulseK+chainK*0.35; ctx.beginPath();
     var amax=Math.PI*5*frac, st2=false;
     for(var a=0;a<=amax;a+=0.14){ var r=2.5+a*2.1, wx=Math.cos(a)*r, wy=Math.sin(a)*r;
       if(!st2){ ctx.moveTo(wx,wy); st2=true; } else ctx.lineTo(wx,wy); }
     ctx.stroke();
-    if(pulseK>0){ ctx.strokeStyle="rgba(255,209,92,"+(pulseK*0.6)+")"; ctx.lineWidth=3; ctx.beginPath(); ctx.arc(0,0,14,0,7); ctx.stroke(); }
+    // the ready-pulse gold grows stronger per chain level
+    if(pulseK>0){ ctx.strokeStyle="rgba(255,209,92,"+Math.min(0.95,pulseK*0.6*(1+chainK*0.45))+")";
+      ctx.lineWidth=3+chainK*0.6; ctx.beginPath(); ctx.arc(0,0,14,0,7); ctx.stroke(); }
     ctx.restore();
     if(S.cool<=0 && !S.busy){ ctx.fillStyle="#b9791a"; ctx.font="700 10px Nunito, sans-serif";
       ctx.fillText("cast ready", g.cx, g.cy+46); }
@@ -2822,7 +3018,12 @@ window.__wh = function(){
   return {
     realtime: CFG.realtime, actions: S.actions, maxActions: S.maxActions,
     cool: +S.cool.toFixed(3), coolMax: S.coolMax, castCd: CFG.castCd,
+    chain: S.chain, readyElapsed: +S.readyElapsed.toFixed(3),
     beatT: +S.beatT.toFixed(3), beatMax: S.beatMax,
+    stats: { waves:S.stats.waves, bestCast:S.stats.bestCast, doublecasts:S.stats.doublecasts, creations:S.stats.creations, motes:S.stats.motes, prisms:S.stats.prisms },
+    nextWaveSpec: S.nextWaveSpec ? { wave:S.nextWaveSpec.wave, elite:S.nextWaveSpec.elite,
+      enemies:S.nextWaveSpec.enemies.map(function(e){ return { lane:e.lane, rung:e.rung, ward:e.ward, brute:e.brute, elite:e.elite, armored:e.armored, healer:e.healer, leech:e.leech, hp:e.hp, dmg:e.dmg }; }) } : null,
+    foes: S.enemies.map(function(e){ return { lane:e.lane, rung:e.rung, ward:e.ward, brute:e.brute, elite:e.elite, armored:e.armored, healer:e.healer, leech:e.leech, hp:e.hp, dmg:e.dmg }; }),
     paused: S.paused, busy: S.busy, phase: S.phase, over: S.over, wave: S.wave, hp: S.hp,
     motes: S.motes, exotics: S.exotics.slice(), rituals: S.rituals.slice(), reagents: Object.keys(S.reagents),
     creations: S.creations.filter(function(c){ return !c.dead; }).map(function(c){ return { kind:c.kind, lane:c.lane, rung:c.rung, hp:c.hp, maxhp:c.maxhp, attack:c.attack, tl:c.tl }; }),

--- a/whorl/lab.html
+++ b/whorl/lab.html
@@ -1,0 +1,808 @@
+<!doctype html>
+<!-- whorl · BOARD LAB — a/b/c board-shape experiment (ring vs rack vs grid).
+     one-file prototype: sandbox (juicy dummy targets) + spot-test (time-to-find, 5-find averages).
+     NOT a product. does not touch the game. -->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover, user-scalable=no" />
+<meta name="theme-color" content="#f0e6cf" />
+<title>Whorl · Board Lab</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23f0e6cf'/%3E%3Ccircle cx='9' cy='9' r='4' fill='%23ef4a5a' stroke='%232c2733' stroke-width='2'/%3E%3Ccircle cx='23' cy='9' r='4' fill='%23f6c445' stroke='%232c2733' stroke-width='2'/%3E%3Ccircle cx='9' cy='23' r='4' fill='%233d8bdf' stroke='%232c2733' stroke-width='2'/%3E%3Ccircle cx='23' cy='23' r='4' fill='%23f2913d' stroke='%232c2733' stroke-width='2'/%3E%3C/svg%3E" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@600;700;800&display=swap" rel="stylesheet" />
+<style>
+:root{
+  --paper:#f0e6cf; --paper2:#fbf5e6; --card:#fffdf6;
+  --ink:#2c2733; --ink-soft:#6b6472;
+  --shadow:rgba(44,39,51,.9);
+  --accent:#ffd15c;
+  --font-d:"Fredoka", system-ui, sans-serif;
+  --font-u:"Nunito", system-ui, sans-serif;
+  --calm:cubic-bezier(.4,0,.2,1); --pop:cubic-bezier(.34,1.7,.6,1);
+}
+*{ box-sizing:border-box; -webkit-tap-highlight-color:transparent; }
+html,body{ margin:0; padding:0; height:100%; overflow:hidden; }
+body{
+  background:var(--paper);
+  background-image:radial-gradient(rgba(44,39,51,.05) 1px, transparent 1.4px);
+  background-size:7px 7px;
+  color:var(--ink); font-family:var(--font-u);
+  -webkit-font-smoothing:antialiased; -webkit-user-select:none; user-select:none;
+  touch-action:none;
+}
+#c{ position:fixed; inset:0; display:block; }
+
+.hud{ position:fixed; top:calc(env(safe-area-inset-top) + 8px); left:0; right:0; z-index:4;
+  display:flex; flex-direction:column; align-items:center; gap:7px; padding:0 10px; pointer-events:none; }
+.hud > *{ pointer-events:auto; }
+.seg{ display:flex; background:var(--paper2); border:2.5px solid var(--ink); border-radius:14px;
+  box-shadow:0 3px 0 var(--shadow); overflow:hidden; }
+.seg button{ font-family:var(--font-d); font-weight:600; font-size:15px; color:var(--ink);
+  background:transparent; border:0; padding:8px 18px; cursor:pointer; touch-action:manipulation;
+  border-right:2.5px solid var(--ink); transition:background .12s var(--calm); }
+.seg button:last-child{ border-right:0; }
+.seg button.on{ background:var(--accent); }
+.row2{ display:flex; gap:8px; align-items:center; }
+.mk{ font-family:var(--font-d); font-weight:600; cursor:pointer; color:var(--ink);
+  background:var(--card); border:2.5px solid var(--ink); border-radius:12px;
+  box-shadow:0 3px 0 var(--shadow); transition:transform .08s var(--calm), box-shadow .08s var(--calm);
+  touch-action:manipulation; padding:6px 13px; font-size:13px; }
+.mk:active{ transform:translateY(3px); box-shadow:0 0 0 var(--shadow); }
+.mk.on{ background:var(--accent); }
+.mk.tiny{ padding:4px 9px; font-size:11px; border-width:2px; border-radius:9px; box-shadow:0 2px 0 var(--shadow); }
+
+.banner{ position:fixed; left:0; right:0; top:calc(env(safe-area-inset-top) + 96px); z-index:4;
+  display:none; justify-content:center; gap:8px; align-items:center; pointer-events:none; }
+.banner.show{ display:flex; }
+.banner .bn{ font-family:var(--font-d); font-weight:700; font-size:15px; color:var(--ink);
+  background:var(--accent); border:2.5px solid var(--ink); border-radius:12px 12px 12px 3px;
+  box-shadow:0 3px 0 var(--shadow); padding:6px 14px; transform:rotate(-1.2deg); }
+.banner .mk{ pointer-events:auto; }
+
+.strip{ position:fixed; left:0; right:0; bottom:calc(env(safe-area-inset-bottom) + 8px); z-index:4;
+  display:flex; flex-direction:column; align-items:center; gap:6px; padding:0 10px; pointer-events:none; }
+.strip > *{ pointer-events:auto; }
+.chip{ display:flex; align-items:center; gap:7px; background:var(--paper2); border:2.5px solid var(--ink);
+  border-radius:12px; box-shadow:0 3px 0 var(--shadow); padding:5px 12px;
+  font-family:var(--font-d); font-weight:600; font-size:12.5px; white-space:nowrap; }
+.chip small{ font-family:var(--font-u); font-weight:800; font-size:8.5px; letter-spacing:.12em;
+  color:var(--ink-soft); text-transform:uppercase; }
+.chip b{ font-weight:700; }
+.chip .sep{ color:rgba(44,39,51,.3); }
+</style>
+</head>
+<body>
+<canvas id="c"></canvas>
+
+<div class="hud">
+  <div class="seg" id="seg">
+    <button data-b="ring" class="on">Ring</button>
+    <button data-b="rack">Rack</button>
+    <button data-b="grid">Grid</button>
+  </div>
+  <div class="row2">
+    <button class="mk" id="btnMode">Spot-test: off</button>
+    <button class="mk" id="btnHint">Hint wiggle: off</button>
+  </div>
+</div>
+
+<div class="banner" id="banner">
+  <span class="bn" id="bnTxt">Find the cast!</span>
+  <button class="mk tiny" id="btnSkip">re-deal</button>
+</div>
+
+<div class="strip">
+  <div class="chip" id="sandChip"><small>Sandbox</small><span id="sandTxt">—</span></div>
+  <div class="chip"><small>Find avg</small><span id="avgTxt">Ring — · Rack — · Grid —</span>
+    <button class="mk tiny" id="btnReset">reset</button></div>
+</div>
+
+<script>
+(function(){
+"use strict";
+
+/* ===================== shared vocabulary (mirrors the game) ===================== */
+var HEX = { R:"#ef4a5a", Y:"#f6c445", B:"#3d8bdf", O:"#f2913d", G:"#57c268", P:"#9b62d6" };
+var NAME = { R:"Red", Y:"Yellow", B:"Blue", O:"Orange", G:"Green", P:"Purple" };
+var PRIM = { R:1, Y:1, B:1 };
+var PARENT = { O:["R","Y"], G:["Y","B"], P:["R","B"] };
+function isPrim(c){ return !!PRIM[c]; }
+function mix(a,b){ var s=[a,b].sort().join("");
+  if(s==="RY") return "O"; if(s==="BY") return "G"; if(s==="BR") return "P"; return null; }
+function pick(a){ return a[(Math.random()*a.length)|0]; }
+function shuffle(a){ a=a.slice(); for(var i=a.length-1;i>0;i--){ var j=(Math.random()*(i+1))|0, t=a[i]; a[i]=a[j]; a[j]=t; } return a; }
+function now(){ return performance.now(); }
+function freshBall(){ return { c:pick(["R","Y","B"]), lvl:1, born:now() }; }
+
+/* the recipe grammar, in miniature — a 3-ball sweep resolves to a spell or a fizzle.
+   RRR/YYY/BBB · OOO/GGG/PPP · secondary+both parents · secondary PAIR+any · R+Y+B=Transmute. */
+function resolveCast(cols){
+  var s={}; cols.forEach(function(c){ s[c]=(s[c]||0)+1; });
+  if(s.R===3) return { name:"Ember",      valid:true, tint:HEX.R };
+  if(s.Y===3) return { name:"Sunburst",   valid:true, tint:HEX.Y };
+  if(s.B===3) return { name:"Frost",      valid:true, tint:HEX.B };
+  if(s.O===3) return { name:"Pyre",       valid:true, tint:HEX.O };
+  if(s.G===3) return { name:"Overgrowth", valid:true, tint:HEX.G };
+  if(s.P===3) return { name:"Eclipse",    valid:true, tint:HEX.P };
+  if(s.R===1 && s.Y===1 && s.B===1) return { name:"Transmute", valid:true, tint:"#9b62d6" };
+  if(s.O===1 && s.R===1 && s.Y===1) return { name:"Blast", valid:true, tint:HEX.O };
+  if(s.P===1 && s.R===1 && s.B===1) return { name:"Lance", valid:true, tint:HEX.P };
+  if(s.G===1 && s.Y===1 && s.B===1) return { name:"Venom", valid:true, tint:HEX.G };
+  if(s.O===2) return { name:"Blast", valid:true, tint:HEX.O };
+  if(s.P===2) return { name:"Lance", valid:true, tint:HEX.P };
+  if(s.G===2) return { name:"Venom", valid:true, tint:HEX.G };
+  return { name:"Fizzle", valid:false, tint:"#b9b2a6" };
+}
+
+/* ===================== canvas ===================== */
+var cv=document.getElementById("c"), ctx=cv.getContext("2d");
+var W,H,DPR;
+function resize(){
+  DPR=Math.min(2, window.devicePixelRatio||1);
+  W=window.innerWidth; H=window.innerHeight;
+  cv.width=W*DPR; cv.height=H*DPR;
+  cv.style.width=W+"px"; cv.style.height=H+"px";
+  ctx.setTransform(DPR,0,0,DPR,0,0);
+  ctx.lineJoin="round"; ctx.lineCap="round";
+  layoutAll();
+}
+window.addEventListener("resize", resize);
+
+/* ===================== the three boards =====================
+   a board = slots (positions) + adj (who counts as "next to"). the SAME sweep
+   and merge code runs on all three; only the adjacency differs:
+     RING — 12 in a circle, adj = i±1 with wrap. a sweep is an arc window.
+     RACK — 12 on a gentle card-fan arc, adj = i±1, NO wrap. windows are left-right runs.
+     GRID — 4x4, adj = 4-way orthogonal. a sweep is any 3-cell orthogonal path. */
+function ringBoard(){
+  var b={ name:"ring", n:12, adj:[], balls:[] };
+  for(var i=0;i<12;i++) b.adj.push([ (i+11)%12, (i+1)%12 ]);
+  b.layout=function(){
+    var dialR=Math.min(W*0.375, 150);
+    var cy=Math.min(H-dialR-70, H*0.60+40);
+    b.ballR=dialR*0.215+8; b.slots=[]; b.cx=W/2; b.cy=cy; b.dialR=dialR;
+    for(var i=0;i<12;i++){
+      var a=-Math.PI/2+i*(Math.PI*2/12);
+      b.slots.push({ x:W/2+Math.cos(a)*dialR, y:cy+Math.sin(a)*dialR });
+    }
+  };
+  return b;
+}
+function rackBoard(){
+  var b={ name:"rack", n:12, adj:[], balls:[] };
+  for(var i=0;i<12;i++){
+    var a=[]; if(i>0)a.push(i-1); if(i<11)a.push(i+1); b.adj.push(a);
+  }
+  b.layout=function(){
+    var m=Math.min(W-36, 372), x0=(W-m)/2, cy=H*0.60+40;
+    b.ballR=Math.min(19, m/12/2+3.5); b.slots=[];
+    for(var i=0;i<12;i++){
+      var u=(i-5.5)/5.5;                      // -1..1 across the hand
+      b.slots.push({ x:x0+(i+0.5)*(m/12), y:cy-26+30*u*u });   // middle sits proud, ends droop — a fanned hand
+    }
+  };
+  return b;
+}
+function gridBoard(){
+  /* 5x5 with FOUR HOLES at (1,1) (1,3) (3,1) (3,3) — 21 playable cells in a pinwheel.
+     holes are not traversable: adjacency simply skips them, so sweeps and merges
+     must ROUTE around them. that bending read is the whole experiment. */
+  var b={ name:"grid", n:25, adj:[], balls:[], hole:{} };
+  [6,8,16,18].forEach(function(i){ b.hole[i]=1; });
+  for(var i=0;i<25;i++){
+    var r=(i/5)|0, c=i%5, a=[];
+    if(!b.hole[i]){
+      if(c>0 && !b.hole[i-1]) a.push(i-1);
+      if(c<4 && !b.hole[i+1]) a.push(i+1);
+      if(r>0 && !b.hole[i-5]) a.push(i-5);
+      if(r<4 && !b.hole[i+5]) a.push(i+5);
+    }
+    b.adj.push(a);
+  }
+  b.layout=function(){
+    var cell=Math.min((W-50)/5, 66), cy=H*0.60+40;
+    b.ballR=cell*0.36; b.slots=[]; b.cell=cell;
+    for(var i=0;i<25;i++){
+      var r=(i/5)|0, c=i%5;
+      b.slots.push({ x:W/2+(c-2)*cell, y:cy+(r-2)*cell });
+    }
+  };
+  return b;
+}
+var BOARDS={ ring:ringBoard(), rack:rackBoard(), grid:gridBoard() };
+var cur=BOARDS.ring;
+function layoutAll(){ Object.keys(BOARDS).forEach(function(k){ BOARDS[k].layout(); }); }
+
+/* every possible 3-slot window a sweep could trace, enumerated once per board.
+   a window is a path a—m—b (a,b distinct neighbours of the middle m); each unique
+   cell-set appears exactly once. ring: 12 · rack: 10 · grid: 52. */
+function windowsOf(b){
+  if(b.wins) return b.wins;
+  var out=[], seen={};
+  for(var m=0;m<b.n;m++){
+    var nb=b.adj[m];
+    for(var x=0;x<nb.length;x++) for(var y=x+1;y<nb.length;y++){
+      var key=[nb[x],m,nb[y]].slice().sort(function(p,q){return p-q;}).join("_");
+      if(!seen[key]){ seen[key]=1; out.push([nb[x],m,nb[y]]); }
+    }
+  }
+  b.wins=out; return out;
+}
+function countValidWindows(b){
+  var n=0;
+  windowsOf(b).forEach(function(w){
+    var cols=w.map(function(i){ return b.balls[i].c; });
+    if(resolveCast(cols).valid) n++;
+  });
+  return n;
+}
+
+/* ===================== state ===================== */
+var mode="sandbox";                 // "sandbox" | "spot"
+var hintOn=false;
+var fx=[], dmgs=[], toastO=null, shake=0;
+var lastInput=now();
+var stats={ ring:{casts:0,fizz:0,ms:0}, rack:{casts:0,fizz:0,ms:0}, grid:{casts:0,fizz:0,ms:0} };
+var avgs={ ring:null, rack:null, grid:null };
+try{ var raw=localStorage.getItem("whlab_avgs"); if(raw){ var p=JSON.parse(raw);
+  ["ring","rack","grid"].forEach(function(k){ if(typeof p[k]==="number") avgs[k]=p[k]; }); } }catch(e){}
+function saveAvgs(){ try{ localStorage.setItem("whlab_avgs", JSON.stringify(avgs)); }catch(e){} }
+var spot={ win:null, t0:0, finds:[], waiting:false };
+var castLog=[];
+
+/* dummy targets — three grey blobs holding still at the top, purely to be hit */
+var enemies=[];
+function makeEnemies(){
+  enemies=[];
+  for(var i=0;i<3;i++) enemies.push({ x:W*(0.25+0.25*i), y:118+ (window.innerHeight>700?58:34),
+    hp:60, max:60, seed:i*2.3+1, hit:0, dead:false, deadAt:0 });
+}
+function aliveEnemies(){ return enemies.filter(function(e){ return !e.dead; }); }
+
+/* ===================== tiny audio ===================== */
+var actx=null;
+function ac(){ if(!actx){ try{ actx=new (window.AudioContext||window.webkitAudioContext)(); }catch(e){} }
+  if(actx&&actx.state==="suspended") actx.resume(); return actx; }
+function beep(f,d,type,g){ var a=ac(); if(!a) return; try{
+  var o=a.createOscillator(),v=a.createGain(),t=a.currentTime;
+  o.type=type||"sine"; o.frequency.value=f; o.connect(v); v.connect(a.destination);
+  v.gain.setValueAtTime(.0001,t); v.gain.linearRampToValueAtTime(g||.05,t+.01);
+  v.gain.exponentialRampToValueAtTime(.0001,t+d); o.start(t); o.stop(t+d+.02); }catch(e){} }
+function sCast(tl){ var st=Math.min(7,2+Math.round(tl/2));
+  for(var i=0;i<st;i++)(function(i){ setTimeout(function(){ beep(300*Math.pow(2,i*3/12),.1,"triangle",.05); }, i*45); })(i); }
+function sFizzle(){ beep(200,.16,"sawtooth",.04); setTimeout(function(){ beep(150,.13,"sawtooth",.03); },100); }
+function sMerge(l){ beep(360+l*70,.08,"triangle",.05); setTimeout(function(){ beep(520+l*80,.08,"triangle",.04); },50); }
+function sFind(){ [523,659,880].forEach(function(f,i){ setTimeout(function(){ beep(f,.14,"triangle",.05); }, i*80); }); }
+function vib(p){ if(navigator.vibrate){ try{ navigator.vibrate(p); }catch(e){} } }
+
+/* ===================== fx ===================== */
+function boom(x,y,col,scale){ fx.push({ ring:true, x:x,y:y, col:col, t:now(), max:(cur.ballR||24)*(scale||1.8) }); }
+function confetti(x,y,col,n){
+  for(var i=0;i<(n||8);i++){
+    var a=Math.random()*Math.PI*2, sp=1.6+Math.random()*2.6;
+    fx.push({ conf:true, x:x,y:y, vx:Math.cos(a)*sp, vy:Math.sin(a)*sp-1.6,
+      col:i%3===0?"#2c2733":col, s:3+Math.random()*2.5, rot:Math.random()*6, t:now() });
+  }
+}
+function puff(x,y){ for(var i=0;i<5;i++) fx.push({ puff:true, x:x+(Math.random()*2-1)*10,
+  y:y+(Math.random()*2-1)*8, vy:-0.35-Math.random()*0.4, s:5+Math.random()*5, t:now()+i*30 }); }
+function spawnDmg(x,y,amt,big){ dmgs.push({ x:x,y:y, amt:amt, t:now(), big:!!big }); }
+function toast(txt,ms,col,big){ toastO={ txt:txt, t:now(), ms:ms||900, col:col||"#2c2733", big:!!big }; }
+
+/* ===================== casting & merging (board-agnostic) ===================== */
+function tlOf(balls){ return balls.reduce(function(s,b){ return s+b.lvl; },0); }
+function refillSlot(b,i,delay){ b.balls[i]=freshBall(); b.balls[i].born=now()+(delay||0); }
+
+function doCast(idxs){
+  var b=cur, balls=idxs.map(function(i){ return b.balls[i]; });
+  var sp=resolveCast(balls.map(function(x){ return x.c; }));
+  var TL=tlOf(balls);
+  var st=stats[b.name];
+  lastInput=now();
+  if(!sp.valid){
+    // the sad puff — a sweep that won't cohere
+    var mx=0,my=0; idxs.forEach(function(i){ mx+=b.slots[i].x/3; my+=b.slots[i].y/3; });
+    puff(mx,my-8); sFizzle(); vib(12); shake=Math.max(shake,2);
+    toast("fizzle…", 650, "#8a8390");
+    if(mode==="sandbox"){ st.fizz++; idxs.forEach(function(i,k){ boom(b.slots[i].x,b.slots[i].y,"#b9b2a6",0.7); refillSlot(b,i,k*50); }); }
+    return sp;                                   // spot-test: board stays intact, keep hunting
+  }
+  // ---- valid cast: this is the moment that has to feel GREAT ----
+  var dmg=3*TL;
+  idxs.forEach(function(i,k){ boom(b.slots[i].x,b.slots[i].y,sp.tint,1.2); });
+  sCast(TL); vib([15,30,25]);
+  shake=Math.min(18, 6+TL*1.2);
+  castLog.push({ name:sp.name, dmg:dmg, board:b.name, mode:mode });
+  if(mode==="sandbox"){
+    st.casts++;
+    var tgt=pick(aliveEnemies().length?aliveEnemies():[null]);
+    if(tgt){
+      fx.push({ beam:true, from:{x:b.slots[idxs[1]].x,y:b.slots[idxs[1]].y}, tgt:{x:tgt.x,y:tgt.y}, t:now(), tint:sp.tint });
+      setTimeout(function(){ hitEnemy(tgt, dmg, sp.tint, TL); }, 110);
+    }
+    toast(sp.name+"  ·  L"+TL, 950, sp.tint==="#f6c445"?"#b9791a":sp.tint, TL>=6);
+    idxs.forEach(function(i,k){ refillSlot(b,i,120+k*60); });
+  } else {
+    spotFound(sp, TL, idxs);
+  }
+  return sp;
+}
+function hitEnemy(e,dmg,tint,TL){
+  if(e.dead) return;
+  e.hp-=dmg; e.hit=now();
+  spawnDmg(e.x, e.y-38, dmg, true);
+  boom(e.x,e.y,tint,2.2); boom(e.x,e.y,"#2c2733",1.3);
+  shake=Math.min(22, shake+4+TL*0.6);
+  beep(160+Math.min(dmg,30)*5,.09,"square",.05);
+  if(e.hp<=0){
+    e.dead=true; e.deadAt=now();
+    confetti(e.x,e.y,"#cfc5b2",10);
+    beep(620,.06,"triangle",.05); setTimeout(function(){ beep(340,.09,"triangle",.04); },60);
+    setTimeout(function(){ e.hp=e.max; e.dead=false; e.deadAt=0; e.born=now();
+      boom(e.x,e.y,"#c9c1b4",1.5); }, 1100);
+  }
+}
+function doMerge(a,bI){
+  var b=cur, A=b.balls[a], B=b.balls[bI];
+  lastInput=now();
+  if(mode==="spot"){ toast("merges are off in spot-test", 900, "#8a8390"); return false; }
+  if(!A||!B) return false;
+  if(A.c===B.c && A.lvl===B.lvl && A.lvl<4){
+    B.lvl++; B.born=now();
+    boom(b.slots[bI].x,b.slots[bI].y,HEX[B.c],1.4); sMerge(B.lvl); vib(14);
+    toast(NAME[B.c]+" L"+B.lvl, 750, HEX[B.c]==="#f6c445"?"#b9791a":HEX[B.c]);
+    refillSlot(b,a,90);
+    return true;
+  }
+  if(isPrim(A.c)&&isPrim(B.c)&&A.c!==B.c&&A.lvl===B.lvl){
+    var m=mix(A.c,B.c);
+    b.balls[bI]={ c:m, lvl:A.lvl, born:now() };
+    boom(b.slots[bI].x,b.slots[bI].y,HEX[m],1.4); sMerge(A.lvl); vib(14);
+    toast(NAME[m]+"!", 750, HEX[m]);
+    refillSlot(b,a,90);
+    return true;
+  }
+  puff(b.slots[bI].x, b.slots[bI].y-6);
+  toast("won't merge", 600, "#8a8390"); beep(220,.08,"sine",.035);
+  return false;
+}
+
+/* ===================== spot-test =====================
+   the deal PLANTS exactly one valid window, then fills everything else so no other
+   window coheres: greedy fill (mostly primaries, ~25% decoy secondaries so secondaries
+   aren't a tell), rejecting any colour that completes a second valid window; verified
+   with a full window count at the end. */
+function plantedRecipe(){
+  var r=Math.random(), secs=["O","G","P"], prims=["R","Y","B"];
+  if(r<0.20){ var c=pick(prims); return [c,c,c]; }
+  if(r<0.38){ var s=pick(secs); return [s,s,s]; }
+  if(r<0.68){ var s2=pick(secs); return shuffle([s2].concat(PARENT[s2])); }
+  if(r<0.90){ var s3=pick(secs); return shuffle([s3,s3,pick(["R","Y","B","O","G","P"].filter(function(c){ return c!==s3; }))]); }
+  return shuffle(["R","Y","B"]);              // Transmute window
+}
+function dealSpot(b){
+  var wins=windowsOf(b);
+  for(var attempt=0; attempt<400; attempt++){
+    var win=pick(wins), rec=plantedRecipe();
+    var balls=new Array(b.n).fill(null);
+    win.forEach(function(i,k){ balls[i]={ c:rec[k], lvl:1, born:now()+k*40 }; });
+    var winKey={}; win.forEach(function(i){ winKey[i]=1; });
+    var rest=shuffle(Object.keys(balls).map(Number).filter(function(i){ return !winKey[i] && !(b.hole&&b.hole[i]); }));
+    var ok=true;
+    for(var ri=0; ri<rest.length && ok; ri++){
+      var idx=rest[ri];
+      var palette=shuffle(["R","Y","B"]);
+      if(Math.random()<0.25) palette.unshift(pick(["O","G","P"]));   // decoy secondary, if it fits safely
+      var placed=false;
+      for(var pi=0; pi<palette.length && !placed; pi++){
+        balls[idx]={ c:palette[pi], lvl:1, born:now()+200+ri*22 };
+        var bad=false;
+        for(var wi=0; wi<wins.length && !bad; wi++){
+          var w=wins[wi];
+          if(w.indexOf(idx)<0) continue;
+          if(w[0]===win[0]&&w[1]===win[1]&&w[2]===win[2]) continue;
+          var cols=[], full=true;
+          for(var ci=0; ci<3; ci++){ if(!balls[w[ci]]){ full=false; break; } cols.push(balls[w[ci]].c); }
+          if(full && resolveCast(cols).valid) bad=true;
+        }
+        if(!bad) placed=true; else balls[idx]=null;
+      }
+      if(!placed) ok=false;
+    }
+    if(!ok) continue;
+    b.balls=balls;
+    if(countValidWindows(b)===1){ spot.win=win.slice(); spot.t0=now(); spot.waiting=false; return; }
+  }
+  // pathological fallback (should never happen): all-primaries + a planted RYB re-attempt
+  dealSpot(b);
+}
+function spotFound(sp, TL, idxs){
+  var b=cur, secs=(now()-spot.t0)/1000;
+  spot.finds.push(secs);
+  spot.waiting=true;
+  idxs.forEach(function(i){ confetti(b.slots[i].x,b.slots[i].y,sp.tint,6); });
+  sFind(); vib([20,40,20]);
+  toast(secs.toFixed(1)+"s !", 1100, "#b9791a", true);
+  if(spot.finds.length>=5){
+    var avg=spot.finds.reduce(function(a,x){ return a+x; },0)/spot.finds.length;
+    avgs[b.name]=Math.round(avg*10)/10;
+    saveAvgs(); renderAvgs();
+    setTimeout(function(){ toast(cap(b.name)+" avg "+avgs[b.name].toFixed(1)+"s", 1600, "#2c2733", true); }, 900);
+    spot.finds=[];
+  }
+  setTimeout(function(){ if(mode==="spot") dealSpot(cur); }, 850);
+}
+function hintActive(t){
+  return mode==="spot" && hintOn && !spot.waiting && spot.win && (t-lastInput>4000) && (t-spot.t0>4000);
+}
+function cap(s){ return s.charAt(0).toUpperCase()+s.slice(1); }
+
+/* ===================== dealing / mode & board switching ===================== */
+function dealSandbox(b){ b.balls=[]; for(var i=0;i<b.n;i++) b.balls.push(b.hole&&b.hole[i]? null : freshBall()); }
+Object.keys(BOARDS).forEach(function(k){ dealSandbox(BOARDS[k]); });
+
+function setBoard(name){
+  if(!BOARDS[name] || cur===BOARDS[name]) return;
+  cancelGesture();
+  cur=BOARDS[name];
+  document.querySelectorAll("#seg button").forEach(function(btn){
+    btn.classList.toggle("on", btn.dataset.b===name);
+  });
+  if(mode==="spot"){ spot.finds=[]; dealSpot(cur); }
+  renderSand();
+}
+function setMode(m){
+  if(m===mode) return;
+  cancelGesture();
+  mode=m;
+  document.getElementById("btnMode").textContent="Spot-test: "+(m==="spot"?"on":"off");
+  document.getElementById("btnMode").classList.toggle("on", m==="spot");
+  document.getElementById("banner").classList.toggle("show", m==="spot");
+  if(m==="spot"){ spot.finds=[]; dealSpot(cur); }
+  else { Object.keys(BOARDS).forEach(function(k){ dealSandbox(BOARDS[k]); }); spot.win=null; }
+}
+
+/* ===================== input (touch + mouse share one path) ===================== */
+var gesture=null;
+function slotAt(x,y){
+  var best=-1, bd=1e9, hitR=cur.ballR*1.4;
+  for(var i=0;i<cur.n;i++){
+    var d=Math.hypot(cur.slots[i].x-x, cur.slots[i].y-y);
+    if(d<hitR && d<bd){ bd=d; best=i; }
+  }
+  return best;
+}
+function down(x,y){
+  lastInput=now(); ac();
+  if(mode==="spot"&&spot.waiting) return;
+  var i=slotAt(x,y);
+  if(i<0 || !cur.balls[i]) return;
+  gesture={ visited:[i], x:x, y:y };
+}
+function move(x,y){
+  if(!gesture) return;
+  lastInput=now();
+  gesture.x=x; gesture.y=y;
+  var i=slotAt(x,y);
+  if(i<0 || !cur.balls[i]) return;
+  var v=gesture.visited, last=v[v.length-1];
+  if(i===last || v.indexOf(i)>=0) return;
+  if(cur.adj[last].indexOf(i)<0) return;      // only a step onto a NEIGHBOUR extends the sweep
+  v.push(i);
+  beep(420+v.length*90,.05,"sine",.03);
+  if(v.length===3){ var idxs=v.slice(); gesture=null; doCast(idxs); }
+}
+function up(){
+  if(!gesture) return;
+  var v=gesture.visited; gesture=null;
+  if(v.length===2) doMerge(v[0], v[1]);       // released on a neighbour = a merge attempt
+}
+function cancelGesture(){ gesture=null; }
+
+function pt(e){ var t=e.touches&&e.touches[0]?e.touches[0]:(e.changedTouches?e.changedTouches[0]:e);
+  return { x:t.clientX, y:t.clientY }; }
+cv.addEventListener("mousedown", function(e){ var p=pt(e); down(p.x,p.y); });
+window.addEventListener("mousemove", function(e){ if(gesture){ var p=pt(e); move(p.x,p.y); } });
+window.addEventListener("mouseup", function(){ up(); });
+cv.addEventListener("touchstart", function(e){ e.preventDefault(); var p=pt(e); down(p.x,p.y); }, {passive:false});
+cv.addEventListener("touchmove", function(e){ e.preventDefault(); if(e.touches.length>1)return; var p=pt(e); move(p.x,p.y); }, {passive:false});
+cv.addEventListener("touchend", function(e){ e.preventDefault(); up(); }, {passive:false});
+/* iOS zoom guards, same as the game */
+document.addEventListener("gesturestart", function(e){ e.preventDefault(); });
+var lastTap=0;
+document.addEventListener("touchend", function(e){ var n=Date.now();
+  if(n-lastTap<300 && !e.target.closest("button")) e.preventDefault(); lastTap=n; }, {passive:false});
+
+/* ===================== DOM controls ===================== */
+document.getElementById("seg").addEventListener("click", function(e){
+  var b=e.target.closest("button"); if(b) setBoard(b.dataset.b);
+});
+document.getElementById("btnMode").addEventListener("click", function(){
+  setMode(mode==="spot"?"sandbox":"spot");
+});
+document.getElementById("btnHint").addEventListener("click", function(){
+  hintOn=!hintOn;
+  this.textContent="Hint wiggle: "+(hintOn?"on":"off");
+  this.classList.toggle("on", hintOn);
+});
+document.getElementById("btnSkip").addEventListener("click", function(){
+  if(mode==="spot"&&!spot.waiting){ dealSpot(cur); toast("re-dealt", 600, "#8a8390"); }
+});
+document.getElementById("btnReset").addEventListener("click", function(){
+  avgs={ ring:null, rack:null, grid:null }; saveAvgs(); renderAvgs(); toast("averages cleared", 800, "#8a8390");
+});
+function renderAvgs(){
+  document.getElementById("avgTxt").textContent =
+    ["ring","rack","grid"].map(function(k){
+      return cap(k)+" "+(avgs[k]==null?"—":avgs[k].toFixed(1)+"s");
+    }).join(" · ");
+}
+function renderSand(){
+  var st=stats[cur.name], min=st.ms/60000;
+  var cpm = (st.casts>0 && min>0.05) ? (st.casts/min).toFixed(1) : "—";
+  var fz = (st.casts+st.fizz>0) ? Math.round(100*st.fizz/(st.casts+st.fizz))+"%" : "—";
+  document.getElementById("sandTxt").textContent =
+    cap(cur.name)+" · "+st.casts+" casts · "+cpm+"/min · fizzle "+fz;
+}
+renderAvgs(); renderSand();
+
+/* ===================== drawing ===================== */
+function inkShadow(pathFn, dy){
+  ctx.save(); ctx.translate(0, dy||3);
+  pathFn(); ctx.fillStyle="rgba(44,39,51,.9)"; ctx.fill();
+  ctx.restore();
+}
+function drawBall(b, px, py, i, t, wig){
+  var r0=cur.ballR*(0.86 + Math.min(b.lvl-1,3)*0.07);
+  var k=Math.min(1, Math.max(0,(t-b.born)/240));
+  var scale=k<1 ? (0.2+0.8*k)*(1+0.25*Math.sin(k*Math.PI)) : 1;   // pop-in overshoot
+  r0*=scale;
+  if(r0<1) return;
+  // hint wiggle: wig is the ball's position ALONG the planted path (-1 = not hinted).
+  // amplitude pulses down the path in order, so on the grid the hint TEACHES the route.
+  var amp=0;
+  if(wig>=0) amp=Math.max(0, Math.sin(t/260 - wig*1.15));
+  var wob=(((i*7)%5)-2)*Math.PI/180 + amp*Math.sin(t/85+i*1.7)*0.10;
+  var dx=amp*Math.sin(t/70+i)*1.8;
+  ctx.save(); ctx.translate(px+dx,py); ctx.rotate(wob);
+  if(b.lvl>=2){ ctx.beginPath(); ctx.arc(0,0,r0+5,0,7); ctx.fillStyle="rgba(255,209,92,"+(0.1*Math.min(b.lvl,4))+")"; ctx.fill(); }
+  function shape(){ ctx.beginPath(); ctx.arc(0,0,r0,0,7); }
+  inkShadow(shape, 3);
+  shape(); ctx.fillStyle=HEX[b.c]; ctx.fill();
+  if(!isPrim(b.c) && PARENT[b.c]){       // a secondary wears its recipe: two parent-tinted crescents
+    var par=PARENT[b.c], j=((i*13)%5)*0.09;
+    ctx.save(); ctx.beginPath(); ctx.arc(0,0,r0-1.2,0,7); ctx.clip();
+    ctx.globalAlpha=0.35; ctx.lineWidth=r0*0.44;
+    ctx.strokeStyle=HEX[par[0]];
+    ctx.beginPath(); ctx.arc(r0*0.30,r0*0.26,r0*0.62, Math.PI*0.72+j, Math.PI*1.42+j); ctx.stroke();
+    ctx.strokeStyle=HEX[par[1]];
+    ctx.beginPath(); ctx.arc(-r0*0.26,-r0*0.22,r0*0.58, -Math.PI*0.28+j, Math.PI*0.46+j); ctx.stroke();
+    ctx.globalAlpha=1; ctx.restore();
+  }
+  shape(); ctx.lineWidth=3; ctx.strokeStyle="#2c2733"; ctx.stroke();
+  ctx.beginPath(); ctx.ellipse(-r0*0.3,-r0*0.38, r0*0.3, r0*0.17, -0.4, 0, 7);
+  ctx.fillStyle="rgba(255,255,255,.4)"; ctx.fill();
+  if(b.lvl>=2){
+    ctx.fillStyle="#fffdf6"; ctx.strokeStyle="#2c2733"; ctx.lineWidth=2;
+    var n=Math.min(b.lvl,4), pw=Math.max(5,r0*0.2), gap=3, tot=n*pw+(n-1)*gap, sx=-tot/2;
+    for(var q=0;q<n;q++){ ctx.beginPath(); ctx.arc(sx+pw/2+q*(pw+gap), r0*0.52, pw/2,0,7); ctx.fill(); ctx.stroke(); }
+  }
+  ctx.restore();
+}
+function drawBoardChrome(t){
+  ctx.strokeStyle="rgba(44,39,51,.14)"; ctx.lineWidth=2.5; ctx.setLineDash([2,7]);
+  if(cur.name==="ring"){
+    ctx.beginPath(); ctx.arc(cur.cx,cur.cy,cur.dialR,0,7); ctx.stroke();
+  } else if(cur.name==="rack"){
+    ctx.beginPath();
+    cur.slots.forEach(function(p,i){ if(i===0)ctx.moveTo(p.x,p.y); else ctx.lineTo(p.x,p.y); });
+    ctx.stroke();
+  } else {
+    // connectors only between traversable neighbours — the lanes visibly bend around the holes
+    for(var i=0;i<cur.n;i++){
+      cur.adj[i].forEach(function(j){
+        if(j<i) return;
+        ctx.beginPath(); ctx.moveTo(cur.slots[i].x,cur.slots[i].y); ctx.lineTo(cur.slots[j].x,cur.slots[j].y); ctx.stroke();
+      });
+    }
+    // holes: a quiet ink cross so the gap reads as "no ball ever lives here"
+    ctx.setLineDash([]);
+    ctx.strokeStyle="rgba(44,39,51,.18)"; ctx.lineWidth=2.5;
+    Object.keys(cur.hole).forEach(function(hi){
+      var p=cur.slots[+hi], s=cur.ballR*0.3;
+      ctx.beginPath(); ctx.moveTo(p.x-s,p.y-s); ctx.lineTo(p.x+s,p.y+s);
+      ctx.moveTo(p.x+s,p.y-s); ctx.lineTo(p.x-s,p.y+s); ctx.stroke();
+    });
+  }
+  ctx.setLineDash([]);
+}
+function drawEnemies(t){
+  enemies.forEach(function(e){
+    var deadK=e.dead? Math.min(1,(t-e.deadAt)/240) : 0;
+    var popK=e.born? Math.min(1,(t-e.born)/240) : 1;
+    var sc=(1-deadK)*(0.3+0.7*popK);
+    if(sc<=0.02) return;
+    var hitK=e.hit? Math.max(0,1-(t-e.hit)/180) : 0;
+    var r=30*sc*(1+hitK*0.12);
+    ctx.save(); ctx.translate(e.x, e.y+Math.sin(t/800+e.seed)*2);
+    function blob(){
+      ctx.beginPath();
+      for(var k=0;k<=24;k++){
+        var a=k/24*Math.PI*2, rr=r*(1+0.07*Math.sin(a*3+e.seed+t/600));
+        var px=Math.cos(a)*rr, py=Math.sin(a)*rr*0.92;
+        if(k===0)ctx.moveTo(px,py); else ctx.lineTo(px,py);
+      }
+      ctx.closePath();
+    }
+    inkShadow(blob, 3);
+    blob(); ctx.fillStyle=hitK>0.4? "#fffdf6" : "#b9b2a6"; ctx.fill();
+    blob(); ctx.lineWidth=3; ctx.strokeStyle="#2c2733"; ctx.stroke();
+    ctx.fillStyle="#2c2733";
+    ctx.beginPath(); ctx.arc(-9,-4,3.2,0,7); ctx.fill();
+    ctx.beginPath(); ctx.arc(9,-4,3.2,0,7); ctx.fill();
+    ctx.strokeStyle="#2c2733"; ctx.lineWidth=2.5;
+    ctx.beginPath(); ctx.arc(0,9,5,Math.PI*0.15,Math.PI*0.85, hitK>0? false : true);
+    if(hitK>0){ ctx.beginPath(); ctx.arc(0,13,5,Math.PI*1.15,Math.PI*1.85); }   // hit = sad mouth
+    else { ctx.beginPath(); ctx.moveTo(-4,8); ctx.lineTo(4,8); }
+    ctx.stroke();
+    ctx.restore();
+    // HP bar
+    if(!e.dead){
+      var bw=64,bh=11,bx=e.x-bw/2,by=e.y+40;
+      ctx.fillStyle="rgba(44,39,51,.9)"; roundRect(bx,by+2.5,bw,bh,5); ctx.fill();
+      ctx.fillStyle="#fffdf6"; roundRect(bx,by,bw,bh,5); ctx.fill();
+      var pct=Math.max(0,e.hp/e.max);
+      ctx.fillStyle= pct>0.55?"#57c268":pct>0.25?"#f6c445":"#ef4a5a";
+      if(pct>0){ roundRect(bx+2,by+2,(bw-4)*pct,bh-4,3); ctx.fill(); }
+      ctx.lineWidth=2.5; ctx.strokeStyle="#2c2733"; roundRect(bx,by,bw,bh,5); ctx.stroke();
+    }
+  });
+}
+function roundRect(x,y,w,h,r){ r=Math.min(r,h/2,w/2); ctx.beginPath();
+  ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r);
+  ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); ctx.closePath(); }
+function drawFx(t){
+  for(var i=fx.length-1;i>=0;i--){
+    var f=fx[i], age=t-f.t;
+    if(age<0) continue;
+    if(f.ring){
+      var k=age/380; if(k>=1){ fx.splice(i,1); continue; }
+      ctx.globalAlpha=1-k;
+      ctx.beginPath(); ctx.arc(f.x,f.y,4+f.max*2.4*k,0,7);
+      ctx.lineWidth=5*(1-k)+1.5; ctx.strokeStyle=f.col; ctx.stroke();
+      ctx.beginPath(); ctx.arc(f.x,f.y,2+f.max*1.7*k,0,7);
+      ctx.lineWidth=2.5; ctx.strokeStyle="rgba(44,39,51,.55)"; ctx.stroke();
+      ctx.globalAlpha=1;
+    } else if(f.conf){
+      var k2=age/750; if(k2>=1){ fx.splice(i,1); continue; }
+      f.x+=f.vx; f.y+=f.vy; f.vy+=0.09;
+      ctx.save(); ctx.translate(f.x,f.y); ctx.rotate(f.rot+age/120);
+      ctx.globalAlpha=1-k2; ctx.fillStyle=f.col;
+      ctx.fillRect(-f.s/2,-f.s/2,f.s,f.s*0.7);
+      ctx.restore(); ctx.globalAlpha=1;
+    } else if(f.puff){
+      var k3=age/600; if(k3>=1){ fx.splice(i,1); continue; }
+      f.y+=f.vy;
+      ctx.globalAlpha=(1-k3)*0.5;
+      ctx.beginPath(); ctx.arc(f.x,f.y,f.s*(0.6+k3),0,7);
+      ctx.fillStyle="#8a8390"; ctx.fill();
+      ctx.globalAlpha=1;
+    } else if(f.beam){
+      var k4=age/260; if(k4>=1){ fx.splice(i,1); continue; }
+      ctx.globalAlpha=(1-k4)*0.9;
+      ctx.lineWidth=6*(1-k4)+2; ctx.strokeStyle=f.tint;
+      ctx.beginPath(); ctx.moveTo(f.from.x,f.from.y);
+      var mx=(f.from.x+f.tgt.x)/2+18, my=(f.from.y+f.tgt.y)/2;
+      ctx.quadraticCurveTo(mx,my,f.tgt.x,f.tgt.y); ctx.stroke();
+      ctx.globalAlpha=1;
+    } else fx.splice(i,1);
+  }
+}
+function drawDmgs(t){
+  for(var i=dmgs.length-1;i>=0;i--){
+    var d=dmgs[i], age=t-d.t, k=age/950;
+    if(k>=1){ dmgs.splice(i,1); continue; }
+    var popK=k<0.16? 1+(1-k/0.16)*0.9 : 1;                 // slams in oversized, settles, floats away
+    var fs=(d.big? 44:18)*popK;
+    ctx.globalAlpha=k>0.7? (1-k)/0.3 : 1;
+    ctx.textAlign="center";
+    ctx.font="700 "+fs.toFixed(1)+"px Fredoka, sans-serif";
+    ctx.strokeStyle="#2c2733"; ctx.lineWidth=d.big?7:3;
+    ctx.fillStyle=d.big? (d.amt>=24? "#ffd15c" : "#fffdf6") : "#fffdf6";
+    var yy=Math.max(d.y-46*k, 106);   // never floats up into the HUD buttons
+    ctx.strokeText(""+d.amt, d.x, yy); ctx.fillText(""+d.amt, d.x, yy);
+    ctx.globalAlpha=1;
+  }
+}
+function drawToast(t){
+  if(!toastO) return;
+  var age=t-toastO.t; if(age>toastO.ms){ toastO=null; return; }
+  var k=age/toastO.ms, a=k<0.15? k/0.15 : (k>0.8? (1-k)/0.2 : 1);
+  ctx.globalAlpha=a; ctx.textAlign="center";
+  ctx.font="700 "+(toastO.big?30:20)+"px Fredoka, sans-serif";
+  var y=cur.name==="grid"? cur.slots[0].y-cur.ballR-34 : (cur.name==="ring"? cur.cy-cur.dialR-cur.ballR-26 : cur.slots[0].y-70);
+  ctx.strokeStyle="#2c2733"; ctx.lineWidth=5; ctx.fillStyle="#fffdf6";
+  ctx.strokeText(toastO.txt, W/2, y);
+  ctx.fillStyle=toastO.col; ctx.fillText(toastO.txt, W/2, y);
+  ctx.globalAlpha=1;
+}
+
+var lastT=now(), sandTick=0;
+function frame(){
+  var t=now(), dt=Math.min(80, t-lastT); lastT=t;
+  if(mode==="sandbox") stats[cur.name].ms+=dt;
+  ctx.clearRect(0,0,W,H);
+  ctx.save();
+  if(shake>0){ ctx.translate((Math.random()*2-1)*shake,(Math.random()*2-1)*shake); shake*=0.86; if(shake<0.4)shake=0; }
+  drawBoardChrome(t);
+  // empty sockets under missing balls
+  ctx.strokeStyle="rgba(44,39,51,.2)"; ctx.lineWidth=2; ctx.setLineDash([2,6]);
+  for(var i=0;i<cur.n;i++){ if(!cur.balls[i] && !(cur.hole&&cur.hole[i])){ ctx.beginPath(); ctx.arc(cur.slots[i].x,cur.slots[i].y,cur.ballR*0.8,0,7); ctx.stroke(); } }
+  ctx.setLineDash([]);
+  if(mode==="sandbox") drawEnemies(t);
+  var hint=hintActive(t);
+  for(var i2=0;i2<cur.n;i2++){
+    var b=cur.balls[i2]; if(!b) continue;
+    var wig=hint? spot.win.indexOf(i2) : -1;
+    drawBall(b, cur.slots[i2].x, cur.slots[i2].y, i2, t, wig);
+  }
+  // gesture trail: visited slots + live tether to the finger
+  if(gesture&&gesture.visited.length>=1){
+    ctx.strokeStyle="rgba(44,39,51,.55)"; ctx.lineWidth=4; ctx.setLineDash([1,8]);
+    ctx.beginPath();
+    gesture.visited.forEach(function(si,k){ var p=cur.slots[si]; if(k===0)ctx.moveTo(p.x,p.y); else ctx.lineTo(p.x,p.y); });
+    ctx.lineTo(gesture.x,gesture.y); ctx.stroke(); ctx.setLineDash([]);
+    gesture.visited.forEach(function(si){
+      ctx.beginPath(); ctx.arc(cur.slots[si].x,cur.slots[si].y,cur.ballR+6,0,7);
+      ctx.lineWidth=3.5; ctx.strokeStyle="#ffd15c"; ctx.stroke();
+    });
+  }
+  drawFx(t); drawDmgs(t); drawToast(t);
+  ctx.restore();
+  // banner + strip text (cheap; every ~150ms)
+  if(t-sandTick>150){
+    sandTick=t;
+    renderSand();
+    if(mode==="spot"){
+      var el=spot.waiting? "✓" : ((t-spot.t0)/1000).toFixed(1)+"s";
+      document.getElementById("bnTxt").textContent="Find the cast! · "+(spot.finds.length+1)+"/5 · "+el;
+    }
+  }
+  requestAnimationFrame(frame);
+}
+
+/* ===================== boot ===================== */
+resize();
+makeEnemies();
+requestAnimationFrame(frame);
+
+/* ===================== debug/API surface for lab instrumentation ===================== */
+window.LAB = {
+  setBoard:setBoard, boardName:function(){ return cur.name; },
+  setMode:setMode, mode:function(){ return mode; },
+  slotXY:function(i){ return { x:cur.slots[i].x, y:cur.slots[i].y }; },
+  n:function(){ return cur.n; },
+  adj:function(i){ return cur.adj[i].slice(); },
+  balls:function(){ return cur.balls.map(function(b){ return b?{c:b.c,lvl:b.lvl}:null; }); },
+  setBalls:function(arr){ cur.balls=arr.map(function(v,i){
+    if(v==null || (cur.hole&&cur.hole[i])) return null;
+    return typeof v==="string"? {c:v,lvl:1,born:now()-999} : {c:v.c,lvl:v.lvl||1,born:now()-999}; }); },
+  holes:function(){ return cur.hole? Object.keys(cur.hole).map(Number) : []; },
+  windows:function(){ return windowsOf(cur).map(function(w){ return w.slice(); }); },
+  countValid:function(){ return countValidWindows(cur); },
+  planted:function(){ return spot.win? spot.win.slice():null; },
+  finds:function(){ return spot.finds.slice(); },
+  avgs:function(){ return { ring:avgs.ring, rack:avgs.rack, grid:avgs.grid }; },
+  stats:function(){ return JSON.parse(JSON.stringify(stats)); },
+  castLog:function(){ return castLog.slice(); },
+  hintActive:function(){ return hintActive(now()); },
+  setHint:function(v){ if(v!==hintOn) document.getElementById("btnHint").click(); },
+  enemies:function(){ return enemies.map(function(e){ return { hp:e.hp, max:e.max, dead:e.dead }; }); }
+};
+
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Four complete, verified builds plus the board-shape lab. Deploys to `izgebayyurt.github.io/whorl/` (and `/whorl/lab.html`).

## Build 10 — free information
Pre-wave readout in the Bazaar (per-lane enemy chips, ward rings, ELITE ribbon; preview === spawn, asserted), armored/elite threat badges, the death-screen run scoreboard with "Run it back", and Flow cast-chaining.

## The board-shape lab — `whorl/lab.html`
Standalone A/B sandbox: Ring vs Rack vs 5×5-with-holes Grid, spot-test timers with per-board averages, hint-wiggle toggle.

## Build 11 — the Bazaar pass + the human retune
- **Shop**: wave-gated rarity tiers with coloured borders, build-weighted rolls (owning a tag doubles same-tag offers), the Arcane Pack (every 3rd wave, $28 pick-1-of-3 — EV-validated as a fair gamble), a retire slot (6/16/26 motes), and **duplicates merge to tier II** at 75% price with 23 upgraded effects and "II" pips.
- **The retune**: difficulty was calibrated to simulation-perfect play; a "human" policy tuned to match the owner's real experience (median death wave ~6, swarmed) drove the fix — slower swarm ramp (`min(8, 2+ceil(0.6w))`), wall attackers now **wind up** (strike, coil, strike — with a visible cue), start HP 30, trash −10%. Human median: 7 → **11**. Difficulty finals: **Gentle** (~15 for a learning player) / **Standard** / **Fierce** (the old bite, for experts). Tier-II economy corrected (Undertow II & Quicksilver II reined in, dead-money IIs buffed).

## Build 12 — the Living Ring
The answer to "spotting combos is genuinely hard," from a four-family modality research sweep (chains/physics/rotation/free-select) that concluded: keep the ring, fix the legibility.
- **The Arrange**: hold a ball to lift it, carry it around the ring (rotary insert — balls flow aside like beads on a string), and every window that would become castable **glows live**, with the hub naming the best release. Build windows instead of hunting them. 1 action in Turns, free in Flow, free cancel.
- Legibility suite graduated by difficulty: one-away pulse, 4s idle hint wiggle (off on Fierce), always-on window arcs on Gentle.
- Merge-shove: merges physically displace neighbours with a springy burst.

## Verification
Every build shipped only after its own suite plus all prior suites ran green with zero page errors (`living_v1` 24/24, `bazaar2_v1` 118 checks, `intel_v1` 33/33, plus rituals/bazaar/grammar/features/dbl/smoke/flow). Three Monte Carlo studies this cycle: the human calibration, the retune validation, and the Bazaar-pass economy audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R96pkZNidSbkw2qLphH6Z7